### PR TITLE
feat: 앱 레이아웃(컨테이너) 잡기

### DIFF
--- a/components/Common/AppLayout/AppLayout.styles.ts
+++ b/components/Common/AppLayout/AppLayout.styles.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+import theme from '@styles/theme';
+
+export const Container = styled.main`
+  background-color: ${theme.colors.gray2};
+`;
+export const ContainerInner = styled.div`
+  background-color: ${theme.colors.white};
+  width: auto;
+  max-width: 375px;
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 0 18px;
+`;

--- a/components/Common/AppLayout/AppLayout.styles.ts
+++ b/components/Common/AppLayout/AppLayout.styles.ts
@@ -2,12 +2,14 @@ import styled from 'styled-components';
 import theme from '@styles/theme';
 
 export const Container = styled.main`
-  background-color: ${theme.colors.gray2};
+  background-color: ${theme.colors.gray7};
 `;
 export const ContainerInner = styled.div`
-  background-color: ${theme.colors.white};
-  width: auto;
-  max-width: 375px;
+  display: flex;
+  flex-direction: column;
+  background-color: ${theme.colors.black};
+  max-width: 480px;
+  width: 100%;
   min-height: 100vh;
   margin: 0 auto;
   padding: 0 18px;

--- a/components/Common/AppLayout/AppLayout.tsx
+++ b/components/Common/AppLayout/AppLayout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AppProps } from 'next/app';
+import { Header } from '@components/Common';
 import { Container, ContainerInner } from './AppLayout.styles';
 
 interface AppLayoutProps {
@@ -9,7 +10,10 @@ interface AppLayoutProps {
 const AppLayout = ({ children }: AppLayoutProps): React.ReactElement => {
   return (
     <Container>
-      <ContainerInner>{children}</ContainerInner>
+      <ContainerInner>
+        <Header />
+        {children}
+      </ContainerInner>
     </Container>
   );
 };

--- a/components/Common/AppLayout/AppLayout.tsx
+++ b/components/Common/AppLayout/AppLayout.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { AppProps } from 'next/app';
+import { Container, ContainerInner } from './AppLayout.styles';
+
+interface AppLayoutProps {
+  children: AppProps | React.ReactNode;
+}
+
+const AppLayout = ({ children }: AppLayoutProps): React.ReactElement => {
+  return (
+    <Container>
+      <ContainerInner>{children}</ContainerInner>
+    </Container>
+  );
+};
+
+export default AppLayout;

--- a/components/Common/Header/Header.styles.ts
+++ b/components/Common/Header/Header.styles.ts
@@ -1,3 +1,6 @@
 import styled from 'styled-components';
 
-export const HeaderWrapper = styled.header``;
+export const HeaderWrapper = styled.header`
+  width: 100%;
+  background-color: gray;
+`;

--- a/components/Example/Example.styles.ts
+++ b/components/Example/Example.styles.ts
@@ -2,6 +2,5 @@ import styled from 'styled-components';
 import theme from '@/styles/theme';
 
 export const ExampleWrap = styled.div`
-  /* background-color: ${theme.colors.primary}; // 방법 1
-  color: ${({ theme }) => theme.colors.black}; // 방법 2 */
+  color: ${theme.colors.white};
 `;

--- a/components/Example/Example.styles.ts
+++ b/components/Example/Example.styles.ts
@@ -2,8 +2,6 @@ import styled from 'styled-components';
 import theme from '@/styles/theme';
 
 export const ExampleWrap = styled.div`
-  background-color: ${theme.colors.primary}; // 방법 1
-  color: ${({ theme }) => theme.colors.black}; // 방법 2
-  width: 400px;
-  height: 400px;
+  /* background-color: ${theme.colors.primary}; // 방법 1
+  color: ${({ theme }) => theme.colors.black}; // 방법 2 */
 `;

--- a/components/Example/Example.tsx
+++ b/components/Example/Example.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import Image from 'next/image';
-import { Header } from '@/components/Common';
 import SvgIcon from 'public/svgs/vercel.svg';
 import { ExampleWrap } from './Example.styles';
 
 const Example = () => (
   <>
     <ExampleWrap>
-      <Header />
       안녕하세요 안녕하세요 안녕하세요......
-      <Image src={SvgIcon} alt="asd" width="283" height="64" />
+      <Image src={SvgIcon} alt="asd" width="250" height="64" />
     </ExampleWrap>
   </>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2412,10 +2412,30 @@
         }
       }
     },
+<<<<<<< HEAD
     "node_modules/@jest/core/node_modules/@jest/transform": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.5.1.tgz",
       "integrity": "sha512-ipON6WtYgl/1329g5AIJVbUuEh0wZVbdpGwC99Jw4LwuoBNS95MVphU6zOeD9pDkon+LLbFL7lOQRapbB8SCHw==",
+=======
+    "@mdx-js/react": {
+      "version": "1.6.22",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
+      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
+      "dev": true,
+      "requires": {}
+    },
+    "@mdx-js/util": {
+      "version": "1.6.22",
+      "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.22.tgz",
+      "integrity": "sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==",
+      "dev": true
+    },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.1.0",
@@ -32427,7 +32447,110 @@
       "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
       "dev": true,
       "requires": {
+<<<<<<< HEAD
         "@xtuc/long": "4.2.2"
+=======
+        "debug": "^4.1.1",
+        "endent": "^2.0.1",
+        "find-cache-dir": "^3.3.1",
+        "flat-cache": "^3.0.4",
+        "micromatch": "^4.0.2",
+        "react-docgen-typescript": "^2.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+          "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "react-docgen-typescript": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
+          "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
+          "dev": true,
+          "requires": {}
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
       }
     },
     "@webassemblyjs/utf8": {
@@ -33565,10 +33688,25 @@
         "open": "^7.0.3"
       }
     },
+<<<<<<< HEAD
     "big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
       "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
+=======
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "requires": {}
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
     },
     "big.js": {
       "version": "5.2.2",
@@ -33662,11 +33800,27 @@
         }
       }
     },
+<<<<<<< HEAD
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
+=======
+    "ajv-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "requires": {}
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
     },
     "boxen": {
       "version": "5.1.2",
@@ -34305,11 +34459,20 @@
         "restore-cursor": "^3.1.0"
       }
     },
+<<<<<<< HEAD
     "cli-spinners": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
       "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
       "dev": true
+=======
+    "babel-plugin-named-asset-import": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
+      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
+      "dev": true,
+      "requires": {}
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
     },
     "cli-table3": {
       "version": "0.6.2",
@@ -37406,6 +37569,7 @@
             "path-exists": "^3.0.0"
           }
         },
+<<<<<<< HEAD
         "p-limit": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -37414,6 +37578,14 @@
           "requires": {
             "p-try": "^2.0.0"
           }
+=======
+        "eslint-plugin-react-hooks": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+          "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+          "dev": true,
+          "requires": {}
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
         },
         "p-locate": {
           "version": "3.0.0",
@@ -37441,11 +37613,20 @@
         }
       }
     },
+<<<<<<< HEAD
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "dev": true
+=======
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "requires": {}
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
     },
     "find-up": {
       "version": "5.0.0",
@@ -37754,10 +37935,24 @@
         }
       }
     },
+<<<<<<< HEAD
     "fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+=======
+    "eslint-plugin-react-hooks": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.4.0.tgz",
+      "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-storybook": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.5.8.tgz",
+      "integrity": "sha512-k67mXT9dOl0z8RFWL9SAQ38NaNst6BjCUDQudaDGjMJHrXncOfCSOz9ROGIVu//zVepZw8D3abdGn9OVvyJ3QA==",
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
       "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
@@ -41886,6 +42081,7 @@
       "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
       "dev": true,
       "requires": {}
+<<<<<<< HEAD
     },
     "match-sorter": {
       "version": "6.3.1",
@@ -41895,6 +42091,8 @@
         "@babel/runtime": "^7.12.5",
         "remove-accents": "0.4.2"
       }
+=======
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
     },
     "md5.js": {
       "version": "1.3.5",
@@ -43893,9 +44091,15 @@
       }
     },
     "react-docgen-typescript": {
+<<<<<<< HEAD
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
       "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
+=======
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-1.22.0.tgz",
+      "integrity": "sha512-MPLbF8vzRwAG3GcjdL+OHQlhgtWsLTXs+7uJiHfEeT3Ur7IsZaNYqRTLQ9sj2nB6M6jylcPCeCmH7qbszJmecg==",
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
       "dev": true,
       "requires": {}
     },
@@ -45748,6 +45952,7 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+<<<<<<< HEAD
     "strict-event-emitter": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.4.tgz",
@@ -45757,6 +45962,8 @@
         "events": "^3.3.0"
       }
     },
+=======
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -48116,6 +48323,7 @@
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "dev": true,
       "requires": {}
+<<<<<<< HEAD
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -48128,6 +48336,8 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+=======
+>>>>>>> 3d648b0 (feat: 앱 레이아웃(컨테이너) 잡기)
     },
     "xtend": {
       "version": "4.0.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from 'styled-components';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import theme from '@/styles/theme';
+import AppLayout from '@/components/Common/AppLayout/AppLayout';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const [queryClient] = useState(() => new QueryClient());
@@ -18,7 +19,9 @@ function MyApp({ Component, pageProps }: AppProps) {
       </Head>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={theme}>
-          <Component {...pageProps} />
+          <AppLayout>
+            <Component {...pageProps} />
+          </AppLayout>
         </ThemeProvider>
         <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
       </QueryClientProvider>


### PR DESCRIPTION
## Description

<!-- 해당 Pull Request에 대한 설명을 해주세요.
해당 Pull Request로 무엇을 성취했는지 간단하게 설명해주세요. 
만약 새롭게 추가한 package(s)가 있다면 기입해주세요.
-->
앱 레이아웃을 간단하게 잡았습니다. (한게 없음)

생각보다 375px에 양쪽 패딩 18px이 들어가니까 컨텐츠가 많이 작아보입니다. 
캐치테이블처럼 100%이미지는 비율대로 줄도록 하고 카드형식은 가로 스크롤로 넘기지않으면 작게 보이긴 할 것 같네요..

width는 반응형으로 할지 적응형으로 할지 등 아직 정하지 않았고 서로 width를 잡는방법이 달라서 일단 뒀습니다. 화요일날에 이야기 해보는걸로 진행해보고싶습니다~ 

Fixes (issue #)

## Changes

<!-- 리뷰어를 위해 변경 사항에 대해 설명해주세요. -->

- Change 1
- Change 2

## Checklist

✅ 이슈 번호를 올바르게 기입했나요? 만약 관련 이슈가 존재하지 않는다면 체크해주세요. 
