### PR TITLE
공용 컴포넌트 - Button 추가

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const toPath = (_path) => path.join(process.cwd(), _path);
 
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+
 module.exports = {
   stories: [
     '../components/**/*.stories.mdx',
@@ -19,6 +21,7 @@ module.exports = {
       ...config,
       resolve: {
         ...config.resolve,
+        plugins: [new TsconfigPathsPlugin({})],
         alias: {
           ...config.resolve.alias,
         },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,6 @@
 import { addDecorator } from '@storybook/react';
+import * as NextImage from 'next/image';
+import '@/styles/globals.css';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -9,6 +11,13 @@ export const parameters = {
     },
   },
 };
+
+const OriginalNextImage = NextImage.default;
+
+Object.defineProperty(NextImage, 'default', {
+  configurable: true,
+  value: (props) => <OriginalNextImage {...props} unoptimized />,
+});
 
 // addDecorator((Story) => (
 //   <Story />

--- a/assets/icons/close.svg
+++ b/assets/icons/close.svg
@@ -1,4 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M18.75 5.25L5.25 18.75" stroke="#F2F2F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M18.75 18.75L5.25 5.25" stroke="#F2F2F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18.75 5.25L5.25 18.75" stroke="#BFBFBF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18.75 18.75L5.25 5.25" stroke="#BFBFBF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/components/Common/Button/Button.stories.tsx
+++ b/components/Common/Button/Button.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import Button, { ButtonProps } from './Button';
+
+export default {
+  component: Button,
+  title: 'Button',
+} as Meta;
+
+const Template: Story<ButtonProps> = (args) => <Button {...args} />;
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  size: 'lg',
+  onClick: action('click the button'),
+  children: 'Button Example',
+};
+
+export const Gray = Template.bind({});
+
+Gray.args = {
+  ...Primary.args,
+  color: 'gray',
+};
+
+export const MediumButton = Template.bind({});
+
+MediumButton.args = {
+  ...Gray.args,
+  size: 'md',
+};

--- a/components/Common/Button/Button.styles.ts
+++ b/components/Common/Button/Button.styles.ts
@@ -1,0 +1,49 @@
+import theme from '@/styles/theme';
+import styled, { css } from 'styled-components';
+import { ButtonProps } from './Button';
+
+const buttonColorStyle = (color: string) => {
+  switch (color) {
+    case 'primary':
+      return css`
+        color: ${theme.colors.black};
+        background-color: ${theme.colors.primary};
+      `;
+
+    case 'gray':
+      return css`
+        color: ${theme.colors.white};
+        background-color: ${theme.colors.gray3};
+      `;
+  }
+};
+
+const buttonSizeStyle = (size: string) => {
+  switch (size) {
+    case 'lg':
+      return css`
+        width: 100%;
+        height: 56px;
+        ${theme.fonts.btn1};
+      `;
+
+    case 'md':
+      return css`
+        padding: 0 33px;
+        height: 42px;
+        ${theme.fonts.btn2};
+      `;
+  }
+};
+
+export const ButtonContainer = styled.button<ButtonProps>`
+  border-radius: 14px;
+
+  ${(props) => buttonSizeStyle(props.size || 'lg')};
+  ${(props) => buttonColorStyle(props.color || 'primary')};
+  ${(props) =>
+    props.hasShadow &&
+    css`
+      box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
+    `}
+`;

--- a/components/Common/Button/Button.tsx
+++ b/components/Common/Button/Button.tsx
@@ -1,0 +1,31 @@
+import React, { MouseEventHandler } from 'react';
+import { ButtonContainer } from './Button.styles';
+
+export interface ButtonProps {
+  children: React.ReactNode;
+  hasShadow?: boolean;
+  size?: 'lg' | 'md';
+  color?: 'primary' | 'gray';
+  onClick: MouseEventHandler<HTMLButtonElement>;
+}
+
+const Button = ({
+  children,
+  size = 'lg',
+  color = 'primary',
+  hasShadow = false,
+  onClick,
+}: ButtonProps): React.ReactElement => {
+  return (
+    <ButtonContainer
+      onClick={onClick}
+      hasShadow={hasShadow}
+      size={size}
+      color={color}
+    >
+      {children}
+    </ButtonContainer>
+  );
+};
+
+export default Button;

--- a/components/Common/Button/Button.tsx
+++ b/components/Common/Button/Button.tsx
@@ -3,9 +3,9 @@ import { ButtonContainer } from './Button.styles';
 
 export interface ButtonProps {
   children: React.ReactNode;
-  hasShadow?: boolean;
-  size?: 'lg' | 'md';
-  color?: 'primary' | 'gray';
+  hasShadow: boolean;
+  size: 'lg' | 'md';
+  color: 'primary' | 'gray';
   onClick: MouseEventHandler<HTMLButtonElement>;
 }
 

--- a/components/Common/ChipButton/ChipButton.stories.tsx
+++ b/components/Common/ChipButton/ChipButton.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import ChipButton, { ChipButtonProps } from './ChipButton';
+
+export default {
+  component: ChipButton,
+  title: 'ChipButton',
+} as Meta;
+
+const Template: Story<ChipButtonProps> = (args) => <ChipButton {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  children: '#Button Example',
+  canDelete: false,
+  onDelete: action('delete the tag'),
+};

--- a/components/Common/ChipButton/ChipButton.styles.ts
+++ b/components/Common/ChipButton/ChipButton.styles.ts
@@ -1,0 +1,25 @@
+import styled, { css } from 'styled-components';
+import Image from 'next/image';
+import theme from '@/styles/theme';
+
+export const ChipButtonContainer = styled.div`
+  display: inline-flex;
+  padding: 6px 14px;
+  border: 1px solid ${theme.colors.gray6};
+  border-radius: 14.5px;
+`;
+
+export const Text = styled.span<{ canDelete: boolean }>`
+  color: ${theme.colors.gray6};
+  ${theme.fonts.btn2};
+
+  ${(props) =>
+    props.canDelete &&
+    css`
+      margin-right: 14px;
+    `}
+`;
+
+export const CloseImage = styled(Image)`
+  cursor: pointer;
+`;

--- a/components/Common/ChipButton/ChipButton.tsx
+++ b/components/Common/ChipButton/ChipButton.tsx
@@ -1,0 +1,32 @@
+import React, { MouseEventHandler } from 'react';
+import CloseIcon from '@/assets/icons/close.svg';
+import { ChipButtonContainer, Text, CloseImage } from './ChipButton.styles';
+
+export interface ChipButtonProps {
+  canDelete?: boolean;
+  onDelete: MouseEventHandler<HTMLImageElement>;
+  children: React.ReactNode;
+}
+
+const ChipButton = ({
+  canDelete = false,
+  onDelete,
+  children,
+}: ChipButtonProps): React.ReactElement => {
+  return (
+    <ChipButtonContainer>
+      <Text canDelete={canDelete}>{children}</Text>
+      {canDelete && (
+        <CloseImage
+          src={CloseIcon}
+          alt="삭제"
+          width={16}
+          height={16}
+          onClick={onDelete}
+        />
+      )}
+    </ChipButtonContainer>
+  );
+};
+
+export default ChipButton;

--- a/components/Common/ChipButton/ChipButton.tsx
+++ b/components/Common/ChipButton/ChipButton.tsx
@@ -3,7 +3,7 @@ import CloseIcon from '@/assets/icons/close.svg';
 import { ChipButtonContainer, Text, CloseImage } from './ChipButton.styles';
 
 export interface ChipButtonProps {
-  canDelete?: boolean;
+  canDelete: boolean;
   onDelete: MouseEventHandler<HTMLImageElement>;
   children: React.ReactNode;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "prettier": "^2.6.2",
         "react-docgen-typescript-loader": "^3.7.2",
         "ts-jest": "^27.1.4",
+        "tsconfig-paths-webpack-plugin": "^3.5.2",
         "typescript": "4.6.3"
       }
     },
@@ -25540,6 +25541,91 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz",
+      "integrity": "sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^3.9.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/enhanced-resolve": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+      "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tsconfig-paths/node_modules/json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -46980,6 +47066,69 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
+    "tsconfig-paths-webpack-plugin": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz",
+      "integrity": "sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "5.9.3",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+          "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.4",
+            "tapable": "^2.2.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tapable": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+          "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "prettier": "^2.6.2",
     "react-docgen-typescript-loader": "^3.7.2",
     "ts-jest": "^27.1.4",
+    "tsconfig-paths-webpack-plugin": "^3.5.2",
     "typescript": "4.6.3"
   },
   "lint-staged": {


### PR DESCRIPTION
## Description

#36

**Button** 
<img width="1049" alt="스크린샷 2022-04-23 오후 8 49 35" src="https://user-images.githubusercontent.com/29244798/164894106-f6a450cb-7f24-4138-aad3-2040d12d8c5b.png">

**Chip component**
<img width="261" alt="스크린샷 2022-04-23 오후 8 38 30" src="https://user-images.githubusercontent.com/29244798/164894109-20ca04fa-4312-49f4-a2fd-f45ce36fd454.png">


## Changes

- storybook 에서 절대경로 사용을 위해 storybook webpack 설정 변경
- storybook 에서 next/image 로드할 수 있게 설정 추가
- Button 컴포넌트 추가 (stories 추가)
- Chip 컴포넌트 추가 (stories 추가)
- close svg icon stroke 컬러 수정

## Checklist

✅ 이슈 번호를 올바르게 기입했나요? 만약 관련 이슈가 존재하지 않는다면 체크해주세요. 
