### PR TITLE
Pages 기본 구조 추가

### DIFF
--- a/pages/mypage/withdraw.tsx
+++ b/pages/mypage/withdraw.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const MyPageWithdraw = () => {
+  return <div>탈퇴 페이지</div>;
+};
+
+export default MyPageWithdraw;

--- a/pages/posts/[postId].tsx
+++ b/pages/posts/[postId].tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+
+const PostDetail = () => {
+  const router = useRouter();
+  const { postId } = router.query;
+
+  return <div>글 상세 페이지 {postId}</div>;
+};
+
+export default PostDetail;

--- a/pages/posts/letters/[letterId].tsx
+++ b/pages/posts/letters/[letterId].tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+
+const LetterDetail = () => {
+  const router = useRouter();
+  const { letterId } = router.query;
+
+  return <div>편지 상세 페이지 {letterId}</div>;
+};
+
+export default LetterDetail;

--- a/pages/posts/letters/write.tsx
+++ b/pages/posts/letters/write.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const LetterWrite = () => {
+  return <div>편지 작성 페이지</div>;
+};
+
+export default LetterWrite;

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Search = () => {
+  return <div>검색 페이지</div>;
+};
+
+export default Search;

--- a/pages/write/complete.tsx
+++ b/pages/write/complete.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const WriteComplete = () => {
+  return <div>기록 페이지</div>;
+};
+
+export default WriteComplete;

--- a/pages/write/current-emotion.tsx
+++ b/pages/write/current-emotion.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const WriteCurrentEmotion = () => {
+  return <div>2차 감정 페이지</div>;
+};
+
+export default WriteCurrentEmotion;

--- a/pages/write/pre-emotion.tsx
+++ b/pages/write/pre-emotion.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const WritePreEmotion = () => {
+  return <div>1차 감정 페이지</div>;
+};
+
+export default WritePreEmotion;

--- a/pages/write/question.tsx
+++ b/pages/write/question.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const WriteQuestion = () => {
+  return <div>기록 페이지</div>;
+};
+
+export default WriteQuestion;


### PR DESCRIPTION
## Description

#26 

## Changes

```
├─ pages
│   ├─ mypage [마이 페이지]
│   │   ├─ withdraw [탈퇴 페이지]
│   ├─ posts [글 리스트 페이지]
│   │   ├─ [postId] [글 상세 페이지]
│   │   └─ letters [편지]
│   │       ├─  [letterId] [편지 상세 페이지]
│   │       └─ write [편지 등록 페이지] 
│   ├─ search [검색 페이지]
│   ├─ write [글 작성]
│   │   ├─ pre-emotion [1차 감정 페이지]
│   │   ├─ question [글 작성 페이지]
│   │   ├─ current-emotion [2차 감정 & 폴더 & 공개설정]
│   │   └─ complete [글 작성 완료 페이지]
│   └─ index [메인 페이지]
```

구두로 논의했던 기본 Routing 에 대해서 추가하였습니다.
**추가로 편지 등록 페이지 /posts/{postId}/letters/write 를 추가하였습니다.
-> /posts/{postId}/letters 는 편지 리스트 페이지 (MVP 이후 기능) 가 추가될 수 있을 것 같아서 분리했어요!**

추가 의견 있으시면 코멘트 주세용!