### PR TITLE
main header 컴포넌트 추가 (#21)

### DIFF
--- a/components/Common/Header/Header.stories.tsx
+++ b/components/Common/Header/Header.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+
+import Header from './Header';
+
+export default {
+  component: Header,
+  title: 'Header',
+} as Meta;
+
+const Template: Story = (args) => <Header {...args} />;
+
+export const MainHeader = Template.bind({});
+
+MainHeader.args = {};

--- a/components/Common/Header/Header.styles.ts
+++ b/components/Common/Header/Header.styles.ts
@@ -1,6 +1,38 @@
+import theme from '@/styles/theme';
 import styled from 'styled-components';
 
 export const HeaderWrapper = styled.header`
-  width: 100%;
-  background-color: gray;
+  position: sticky;
+  top: 0;
+  display: flex;
+  justify-content: space-between;
+  background-color: ${theme.colors.gray1};
+  height: 44px;
+  padding: 0 18px;
+  margin-right: -18px;
+  margin-left: -18px;
+`;
+
+export const TitleWrapper = styled.button`
+  display: flex;
+  align-items: center;
+
+  span {
+    transform: rotate(-90deg);
+  }
+`;
+
+export const Title = styled.h1`
+  ${theme.fonts.h3};
+  margin-right: 5px;
+  color: ${theme.colors.white};
+  line-height: 18px;
+
+  span {
+    transform: rotate(-90deg);
+  }
+`;
+
+export const Button = styled.button`
+  height: 24px;
 `;

--- a/components/Common/Header/Header.tsx
+++ b/components/Common/Header/Header.tsx
@@ -1,10 +1,30 @@
 import React from 'react';
-import { HeaderWrapper } from './Header.styles';
+import Image from 'next/image';
+import { HeaderWrapper, Title, TitleWrapper } from './Header.styles';
+import MagnifyingGlassIcon from 'public/svgs/magnifyingglass.svg';
+import LeftIcon from 'public/svgs/left.svg';
 
-const Header = () => (
-  <>
-    <HeaderWrapper>header</HeaderWrapper>
-  </>
-);
+const Header = () => {
+  // main header 먼저 작업
+  const MainHeader = () => (
+    <>
+      <TitleWrapper>
+        <Title>서비스명</Title>
+        <Image src={LeftIcon} alt="메뉴" />
+      </TitleWrapper>
+      <button>
+        <Image src={MagnifyingGlassIcon} alt="검색" />
+      </button>
+    </>
+  );
+
+  return (
+    <>
+      <HeaderWrapper>
+        <MainHeader />
+      </HeaderWrapper>
+    </>
+  );
+};
 
 export default Header;

--- a/components/Common/Header/Header.tsx
+++ b/components/Common/Header/Header.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 
 const Header = () => {
   const router = useRouter();
+  const handleButtonClick = () => router.push('/search');
 
   // TODO: main header 이후 다른 페이지 헤더 작업 예정
   const MainHeader = () => (
@@ -15,7 +16,7 @@ const Header = () => {
         <Title>서비스명</Title>
         <Image src={LeftIcon} alt="메뉴" width={16} height={16} />
       </TitleWrapper>
-      <button onClick={() => router.push('/search')}>
+      <button onClick={handleButtonClick}>
         <Image src={MagnifyingGlassIcon} alt="검색" width={24} height={24} />
       </button>
     </>

--- a/components/Common/Header/Header.tsx
+++ b/components/Common/Header/Header.tsx
@@ -3,17 +3,20 @@ import Image from 'next/image';
 import { HeaderWrapper, Title, TitleWrapper } from './Header.styles';
 import MagnifyingGlassIcon from 'public/svgs/magnifyingglass.svg';
 import LeftIcon from 'public/svgs/left.svg';
+import { useRouter } from 'next/router';
 
 const Header = () => {
+  const router = useRouter();
+
   // TODO: main header 이후 다른 페이지 헤더 작업 예정
   const MainHeader = () => (
     <>
       <TitleWrapper>
         <Title>서비스명</Title>
-        <Image src={LeftIcon} alt="메뉴" />
+        <Image src={LeftIcon} alt="메뉴" width={16} height={16} />
       </TitleWrapper>
-      <button>
-        <Image src={MagnifyingGlassIcon} alt="검색" />
+      <button onClick={() => router.push('/search')}>
+        <Image src={MagnifyingGlassIcon} alt="검색" width={24} height={24} />
       </button>
     </>
   );

--- a/components/Common/Header/Header.tsx
+++ b/components/Common/Header/Header.tsx
@@ -5,7 +5,7 @@ import MagnifyingGlassIcon from 'public/svgs/magnifyingglass.svg';
 import LeftIcon from 'public/svgs/left.svg';
 
 const Header = () => {
-  // main header 먼저 작업
+  // TODO: main header 이후 다른 페이지 헤더 작업 예정
   const MainHeader = () => (
     <>
       <TitleWrapper>

--- a/components/Home/Tabs.tsx
+++ b/components/Home/Tabs.tsx
@@ -64,8 +64,7 @@ const Tabs = ({
 
 const TabContainer = styled.div`
   position: sticky;
-  // TODO: Header 높이에 맞춰서 top 위치 변경
-  top: 0;
+  top: 44px;
 `;
 
 const TabList = styled.div`


### PR DESCRIPTION
## Description

Fixes (issue #21)
메인페이지 Header 컴포넌트 스타일 작성

## Changes

- Header 컴포넌트에 현재 디자인가이드 스타일 적용
- 메인페이지랑 다른 페이지의 Header 컴포넌트 스타일이 달라야해서 우선 MainHeader 로 함수를 분리해뒀습니다.

**최상단 페이지**

<img width="483" alt="스크린샷 2022-04-28 오후 10 08 52" src="https://user-images.githubusercontent.com/29244798/165759382-2ac23d05-1de5-486c-861e-310429e716b7.png">

**스크롤 시**

<img width="478" alt="스크린샷 2022-04-28 오후 10 09 00" src="https://user-images.githubusercontent.com/29244798/165759365-ca8004ac-b59a-49d2-8225-4971934365bd.png">

-> 디자인 가이드랑 background color 가 조금 다른데 scroll 시에는 다른 컬러로 되어있어야해서,, 이 부분은 이후에 작업하려고 합니다!
