### PR TITLE
메인페이지 드롭다운 메뉴 컴포넌트 추가 (#25)

### DIFF
--- a/components/Common/AppLayout/AppLayout.tsx
+++ b/components/Common/AppLayout/AppLayout.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { useRecoilValue } from 'recoil';
 import { Header } from '@/components/Common';
 import { Toast } from '@/components/Common';
 import { Container, ContainerInner } from './AppLayout.styles';
 import { toastStateAtom } from '@/store/toast/atom';
-import { useRecoilValue } from 'recoil';
+import DropdownMenu from '../DropdownMenu/DropdownMenu';
+import { dropdownStateAtom } from '@/store/dropdown/atom';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -11,10 +13,13 @@ interface AppLayoutProps {
 
 const AppLayout = ({ children }: AppLayoutProps): React.ReactElement => {
   const toastType = useRecoilValue(toastStateAtom);
+  const dropdownState = useRecoilValue(dropdownStateAtom);
+
   return (
     <>
       <Container>
         <ContainerInner>
+          {dropdownState && <DropdownMenu />}
           <Header />
           {children}
         </ContainerInner>

--- a/components/Common/Button/Button.tsx
+++ b/components/Common/Button/Button.tsx
@@ -1,13 +1,11 @@
-import React, { MouseEventHandler } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import { ButtonContainer } from './Button.styles';
 
-export interface ButtonProps {
-  children: React.ReactNode;
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   size?: 'large' | 'medium' | 'small';
   color?: 'primary' | 'gray';
   hasShadow?: boolean;
   hasBorderRadius?: boolean;
-  onClick: MouseEventHandler<HTMLButtonElement>;
 }
 
 const Button = ({
@@ -16,15 +14,15 @@ const Button = ({
   color = 'primary',
   hasShadow = false,
   hasBorderRadius = true,
-  onClick,
+  ...rest
 }: ButtonProps): React.ReactElement => {
   return (
     <ButtonContainer
-      onClick={onClick}
       size={size}
       color={color}
       hasShadow={hasShadow}
       hasBorderRadius={hasBorderRadius}
+      {...rest}
     >
       {children}
     </ButtonContainer>

--- a/components/Common/DropdownMenu/DropdownMenu.tsx
+++ b/components/Common/DropdownMenu/DropdownMenu.tsx
@@ -11,7 +11,7 @@ const DropdownMenu = (): React.ReactElement => {
   const setDropdownState = useSetRecoilState(dropdownStateAtom);
 
   const dropdownRef =
-    typeof window !== 'undefined' && document.getElementById('dropdown-menu3');
+    typeof window !== 'undefined' && document.getElementById('dropdown-menu');
 
   const unsetDropdownState = () => {
     setDropdownState(false);

--- a/components/Common/DropdownMenu/DropdownMenu.tsx
+++ b/components/Common/DropdownMenu/DropdownMenu.tsx
@@ -7,17 +7,17 @@ import LeftIcon from 'public/svgs/left.svg';
 import { createPortal } from 'react-dom';
 import { dropdownStateAtom } from '@/store/dropdown/atom';
 
-const DropdownMenu = (): React.ReactElement | null => {
+const DropdownMenu = (): React.ReactElement => {
   const setDropdownState = useSetRecoilState(dropdownStateAtom);
 
   const dropdownRef =
-    typeof window !== 'undefined' && document.getElementById('dropdown-menu');
+    typeof window !== 'undefined' && document.getElementById('dropdown-menu3');
 
   const unsetDropdownState = () => {
     setDropdownState(false);
   };
 
-  if (!dropdownRef) return null;
+  if (!dropdownRef) return <></>;
 
   return createPortal(
     <DropdownContainer>

--- a/components/Common/DropdownMenu/DropdownMenu.tsx
+++ b/components/Common/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,99 @@
+import theme from '@/styles/theme';
+import React from 'react';
+import { useSetRecoilState } from 'recoil';
+import Image from 'next/image';
+import styled from 'styled-components';
+import LeftIcon from 'public/svgs/left.svg';
+import { createPortal } from 'react-dom';
+import { dropdownStateAtom } from '@/store/dropdown/atom';
+
+const DropdownMenu = (): React.ReactElement | null => {
+  const setDropdownState = useSetRecoilState(dropdownStateAtom);
+
+  const dropdownRef =
+    typeof window !== 'undefined' && document.getElementById('dropdown-menu');
+
+  const unsetDropdownState = () => {
+    setDropdownState(false);
+  };
+
+  if (!dropdownRef) return null;
+
+  return createPortal(
+    <DropdownContainer>
+      <Dimmed onClick={unsetDropdownState} />
+      <Dropdown>
+        <LogoTitle>서비스명</LogoTitle>
+        <MenuList>
+          <MenuItem>마이페이지</MenuItem>
+          <MenuItem>피드백 / 문의사항 보내기</MenuItem>
+          <MenuItem>개발자 소개</MenuItem>
+          <MenuItem>SNS 계정</MenuItem>
+        </MenuList>
+        <ScrollUpButton onClick={unsetDropdownState}>
+          <Image src={LeftIcon} alt="닫기" width={16} height={16} />
+        </ScrollUpButton>
+      </Dropdown>
+    </DropdownContainer>,
+    dropdownRef,
+  );
+};
+
+const DropdownContainer = styled.div`
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  max-width: 480px;
+  height: 100%;
+  margin: 0 auto;
+  z-index: 10000;
+`;
+
+const Dimmed = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: rgba(68, 53, 53, 0.6);
+`;
+
+const LogoTitle = styled.h2`
+  margin-bottom: 12px;
+  ${theme.fonts.h4};
+  color: ${theme.colors.primary};
+`;
+
+const Dropdown = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 33px 36px 42px;
+  background-color: ${theme.colors.gray2};
+  border-radius: 0 0 35px 35px;
+  z-index: 1;
+`;
+
+const MenuList = styled.ul`
+  list-style: none;
+`;
+
+const MenuItem = styled.li`
+  padding: 22px 0;
+  ${theme.fonts.h6};
+  color: ${theme.colors.white};
+
+  & ~ & {
+    border-top: 1px solid ${theme.colors.gray3};
+  }
+`;
+
+const ScrollUpButton = styled.button`
+  position: absolute;
+  right: 50%;
+  width: 16px;
+  height: 16px;
+  text-align: center;
+  margin: 0 auto;
+  transform: rotate(-270deg);
+`;
+
+export default DropdownMenu;

--- a/components/Common/Header/Header.tsx
+++ b/components/Common/Header/Header.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
+import { useSetRecoilState } from 'recoil';
+import { dropdownStateAtom } from '@/store/dropdown/atom';
 import { HeaderWrapper, Title, TitleWrapper } from './Header.styles';
 import MagnifyingGlassIcon from 'public/svgs/magnifyingglass.svg';
 import LeftIcon from 'public/svgs/left.svg';
@@ -7,12 +9,20 @@ import { useRouter } from 'next/router';
 
 const Header = () => {
   const router = useRouter();
-  const handleButtonClick = () => router.push('/search');
+  const setDropdownState = useSetRecoilState<boolean>(dropdownStateAtom);
+
+  const handleButtonClick = () => {
+    router.push('/search');
+  };
+
+  const handleLogoClick = () => {
+    setDropdownState(true);
+  };
 
   // TODO: main header 이후 다른 페이지 헤더 작업 예정
   const MainHeader = () => (
     <>
-      <TitleWrapper>
+      <TitleWrapper onClick={handleLogoClick}>
         <Title>서비스명</Title>
         <Image src={LeftIcon} alt="메뉴" width={16} height={16} />
       </TitleWrapper>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -50,6 +50,7 @@ class MyDocument extends Document {
         <body>
           <Main />
           <div id="root-bottomsheet" />
+          <div id="dropdown-menu" />
           <div id="root-dialog" />
           <NextScript />
         </body>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,11 +4,8 @@ import { HOME_TAB_TYPE, CurrentTabType } from '@/shared/constants/home';
 import HomeBanner from '@/components/Home/Banner/Banner';
 import HomeTabHeader from '@/components/Home/TabHeader/TabHeader';
 import HomeTabs from '@/components/Home/Tabs/Tabs';
-import BottomSheetExample from '@/components/Example/BottomSheetExample';
-import ModalExample from '@/components/Example/ModalExample';
 import FolderList from '@/components/Home/FolderList/FolderList';
 import WritingButon from '@/components/Common/WritingButton/WritingButton';
-import ToastExample from '@/components/Example/ToastExample';
 
 const Home = () => {
   const router = useRouter();
@@ -30,9 +27,6 @@ const Home = () => {
         setCurrentTab={(tab: CurrentTabType) => setCurrentTab(tab)}
         onClick={() => console.log('폴더 추가')}
       />
-      <BottomSheetExample />
-      <ToastExample />
-      <ModalExample />
       <FolderList />
       <WritingButon onClick={() => router.push('/write/pre-emotion')} />
     </>

--- a/store/dropdown/atom.ts
+++ b/store/dropdown/atom.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const dropdownStateAtom = atom<boolean>({
+  key: 'dropdownState',
+  default: false,
+});

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -28,6 +28,7 @@ const fonts = {
   `,
   h4: () => css`
     font-size: 1.6rem;
+    font-weight: 500;
   `,
   h5: () => css`
     font-size: 1.4rem;
@@ -35,17 +36,21 @@ const fonts = {
   `,
   h6: () => css`
     font-size: 1.4rem;
+    font-weight: 500;
   `,
   subtitle1: () => css`
     font-size: 2.4rem;
+    font-weight: 500;
     line-height: 144%;
   `,
   body: () => css`
     font-size: 1.4rem;
+    font-weight: 500;
     line-height: 170%;
   `,
   caption1: () => css`
     font-size: 1.2rem;
+    font-weight: 500;
   `,
   caption2: () => css`
     font-size: 1.2rem;
@@ -58,6 +63,7 @@ const fonts = {
   `,
   btn2: () => css`
     font-size: 1.4rem;
+    font-weight: 500;
     line-height: 1.6rem;
   `,
 } as const;


### PR DESCRIPTION
## Description

issue #25 
메인페이지에서 노출되는 드롭다운 메뉴

## Changes

https://user-images.githubusercontent.com/29244798/166090007-9858c17d-3d7b-499d-9eaf-6c980dadc2ff.mov

 
**💅 style 변경**
- styles/theme font-weight normal 부분 500 으로 변경

 
**👏 메인페이지 드롭다운**
- DropdownMenu 컴포넌트 추가
   - portal 이용해서 app 외부에서 렌더링 될 수 있게 작업하였습니다.
- dropdownStateAtom 상태 추가


## Checklist
- [x] 드롭다운 컴포넌트 작업
- [ ] 애니메이션 추가

-> 애니메이션은 아직 추가하지않았습니다! 아무래도 API 연동 작업을 먼저 해보는게 백엔드 파트에 좋을 것 같아서 현재 최소 기능 구현을 하고 있습니다. API 붙여보고 디테일한 디자인 & 애니메이션은 수정하겠습니다!!