### PR TITLE
메인페이지 > 편집 시 UI 작업 (#23)

### DIFF
--- a/components/Common/Header/Header.styles.ts
+++ b/components/Common/Header/Header.styles.ts
@@ -2,6 +2,7 @@ import theme from '@/styles/theme';
 import styled from 'styled-components';
 
 export const HeaderWrapper = styled.header`
+  z-index: 101;
   position: sticky;
   top: 0;
   display: flex;

--- a/components/Home/Folder/Folder.styles.ts
+++ b/components/Home/Folder/Folder.styles.ts
@@ -2,16 +2,13 @@ import styled from 'styled-components';
 import theme from '@/styles/theme';
 
 export const FolderContainer = styled.figure`
+  position: relative;
   width: 100%;
   height: 100%;
 `;
 
-export const Caption = styled.figcaption`
-  padding-top: 8px;
-`;
-
 export const FolderName = styled.p`
-  margin-bottom: 4px;
+  margin-bottom: 0.4rem;
   ${theme.fonts.btn2};
   color: ${theme.colors.white};
 `;
@@ -21,10 +18,24 @@ export const FolderCount = styled.span`
   color: ${theme.colors.gray4};
 `;
 
-export const ImageConatiner = styled.div`
-  height: 100%;
-`;
-
 export const BoxContainer = styled.figure`
   display: flex;
+`;
+
+export const CaptionContainer = styled.figcaption`
+  display: flex;
+  align-items: flex-start;
+  margin-top: 0.8rem;
+`;
+
+export const DeleteButton = styled.button`
+  position: absolute;
+  top: 0.8rem;
+  right: 0.8rem;
+`;
+
+export const EditButton = styled.button`
+  width: 2.4rem;
+  height: 2.4rem;
+  margin-right: 0.8rem;
 `;

--- a/components/Home/Folder/Folder.tsx
+++ b/components/Home/Folder/Folder.tsx
@@ -30,6 +30,22 @@ const Folder = ({
   thumbnail = '',
   isEditMode = false,
 }: FolderProps): React.ReactElement => {
+  const renderDeleteButton = () => {
+    return (
+      <DeleteButton onClick={() => console.log('delete')}>
+        <Image src={TrashIcon} alt="삭제" />
+      </DeleteButton>
+    );
+  };
+
+  const renderEditButton = () => {
+    return (
+      <EditButton onClick={() => console.log('edit')}>
+        <Image src={EditFolderIcon} alt="편집" />
+      </EditButton>
+    );
+  };
+
   return (
     <FolderContainer>
       <BoxContainer>
@@ -38,18 +54,10 @@ const Folder = ({
         ) : (
           <Image src={thumbnail || EmptyImage} alt={name} />
         )}
-        {isEditMode && (
-          <DeleteButton onClick={() => console.log('delete')}>
-            <Image src={TrashIcon} alt="삭제" />
-          </DeleteButton>
-        )}
+        {isEditMode && renderDeleteButton()}
       </BoxContainer>
       <CaptionContainer>
-        {isEditMode && (
-          <EditButton onClick={() => console.log('edit')}>
-            <Image src={EditFolderIcon} alt="편집" />
-          </EditButton>
-        )}
+        {isEditMode && renderEditButton()}
         <div>
           <FolderName>{name}</FolderName>
           <FolderCount>{count}</FolderCount>

--- a/components/Home/Folder/Folder.tsx
+++ b/components/Home/Folder/Folder.tsx
@@ -2,11 +2,16 @@ import React from 'react';
 import Image from 'next/image';
 import {
   FolderContainer,
-  Caption,
   FolderName,
   FolderCount,
+  EditButton,
+  DeleteButton,
+  BoxContainer,
+  CaptionContainer,
 } from './Folder.styles';
 import EmptyImage from 'public/images/empty.png';
+import TrashIcon from 'public/svgs/trash.svg';
+import EditFolderIcon from 'public/svgs/editfolder.svg';
 
 export interface Folder {
   name: string;
@@ -15,6 +20,7 @@ export interface Folder {
 }
 
 export interface FolderProps extends Folder {
+  isEditMode?: boolean;
   supportsMultipleLayout?: boolean;
 }
 
@@ -22,18 +28,33 @@ const Folder = ({
   name,
   count,
   thumbnail = '',
+  isEditMode = false,
 }: FolderProps): React.ReactElement => {
   return (
     <FolderContainer>
-      {count === 0 ? (
-        <Image src={EmptyImage} alt="기록이 없어요" />
-      ) : (
-        <Image src={thumbnail || EmptyImage} alt={name} />
-      )}
-      <Caption>
-        <FolderName>{name}</FolderName>
-        <FolderCount>{count}</FolderCount>
-      </Caption>
+      <BoxContainer>
+        {count === 0 ? (
+          <Image src={EmptyImage} alt="기록이 없어요" />
+        ) : (
+          <Image src={thumbnail || EmptyImage} alt={name} />
+        )}
+        {isEditMode && (
+          <DeleteButton onClick={() => console.log('delete')}>
+            <Image src={TrashIcon} alt="삭제" />
+          </DeleteButton>
+        )}
+      </BoxContainer>
+      <CaptionContainer>
+        {isEditMode && (
+          <EditButton onClick={() => console.log('edit')}>
+            <Image src={EditFolderIcon} alt="편집" />
+          </EditButton>
+        )}
+        <div>
+          <FolderName>{name}</FolderName>
+          <FolderCount>{count}</FolderCount>
+        </div>
+      </CaptionContainer>
     </FolderContainer>
   );
 };

--- a/components/Home/FolderList/FolderList.tsx
+++ b/components/Home/FolderList/FolderList.tsx
@@ -3,7 +3,11 @@ import styled from 'styled-components';
 import HomeFolder from '@/components/Home/Folder/Folder';
 import HomeCollectedFolder from '@/components/Home/CollectedFolder/CollectedFolder';
 
-const FolderList = (): React.ReactElement => {
+interface FolderListProps {
+  isEditMode: boolean;
+}
+
+const FolderList = ({ isEditMode }: FolderListProps): React.ReactElement => {
   const folderList = [
     {
       name: '폴더명1',
@@ -56,7 +60,13 @@ const FolderList = (): React.ReactElement => {
     <FolderListContainer>
       <HomeCollectedFolder count={3} items={folderList} />
       {folderList.map((folder) => (
-        <HomeFolder key={folder.name} name="폴더명" count={3} thumbnail="" />
+        <HomeFolder
+          key={folder.name}
+          name="폴더명"
+          count={3}
+          thumbnail=""
+          isEditMode={isEditMode}
+        />
       ))}
     </FolderListContainer>
   );
@@ -65,9 +75,9 @@ const FolderList = (): React.ReactElement => {
 const FolderListContainer = styled.ul`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  column-gap: 8px;
-  row-gap: 14px;
-  padding-top: 20px;
+  column-gap: 0.8rem;
+  row-gap: 1.4rem;
+  padding-top: 2rem;
 `;
 
 export default FolderList;

--- a/components/Home/FolderList/FolderList.tsx
+++ b/components/Home/FolderList/FolderList.tsx
@@ -63,7 +63,7 @@ const FolderList = ({ isEditMode }: FolderListProps): React.ReactElement => {
         <HomeFolder
           key={folder.name}
           name="폴더명"
-          count={3}
+          count={folder.count}
           thumbnail=""
           isEditMode={isEditMode}
         />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,14 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
+import styled from 'styled-components';
 import { HOME_TAB_TYPE, CurrentTabType } from '@/shared/constants/home';
+import { transition } from '@/styles/mixins';
 import HomeBanner from '@/components/Home/Banner/Banner';
 import HomeTabHeader from '@/components/Home/TabHeader/TabHeader';
 import HomeTabs from '@/components/Home/Tabs/Tabs';
 import FolderList from '@/components/Home/FolderList/FolderList';
 import WritingButon from '@/components/Common/WritingButton/WritingButton';
+import CommonButton from '@/components/Common/Button/Button';
 
 const Home = () => {
   const router = useRouter();
@@ -27,24 +30,31 @@ const Home = () => {
         setCurrentTab={(tab: CurrentTabType) => setCurrentTab(tab)}
         onClick={() => console.log('폴더 추가')}
       />
-      <FolderList />
+      <FolderList isEditMode={isEditMode} />
       <WritingButon onClick={() => router.push('/write/pre-emotion')} />
+      <FloatingContainer>
+        <div>
+          <CommonButton color="gray" onClick={() => router.push('/posts')}>
+            지난 감정 되돌아보기
+          </CommonButton>
+        </div>
+      </FloatingContainer>
     </>
   );
 };
 
-if (process.env.NODE_ENV === 'development') {
-  if (typeof window === 'undefined') {
-    (async () => {
-      const { server } = await import('@/mocks/server');
-      server.listen();
-    })();
-  } else {
-    (async () => {
-      const { worker } = await import('@/mocks/browser');
-      worker.start();
-    })();
+const FloatingContainer = styled.div`
+  ${transition()};
+  position: fixed;
+  left: 0;
+  bottom: 5.6rem;
+  width: 100%;
+  z-index: 1001;
+
+  > div {
+    width: 22.3rem;
+    margin: 0 auto;
   }
-}
+`;
 
 export default Home;

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const PostList = () => {
+  return <div>글 목록 페이지</div>;
+};
+
+export default PostList;


### PR DESCRIPTION
## Description

**issue #23**

편집 시, 편집이 가능하게 편집 버튼, 삭제 버튼이 노출되게끔 작업하였습니다.

## Changes

- Header z-index 조정
- 최상단 컴포넌트에서 FolderList, Folder 컴포넌트까지 isEditMode props drilling
- Floating Action Button 추가
- msw start 하는 부분 제거

## 스크린샷

**편집 시**
<img width="475" alt="스크린샷 2022-05-01 오전 11 39 55" src="https://user-images.githubusercontent.com/29244798/166130030-a4d17bc8-bc2f-405c-a626-339bd568fcb5.png">

**FAB 버튼**
<img width="474" alt="스크린샷 2022-05-01 오전 11 49 37" src="https://user-images.githubusercontent.com/29244798/166130107-342a1c98-ac7e-4a7e-8c27-c18e4f6be3b2.png">

## Checklist
- [ ] 현재 svg 를 image 에 추가해서 사용했었는데 이 부분을 개선할 필요가 있다고 생각되서 개선하는 PR 을 올릴 예정입니다.
- [ ] Floating Action Button, 글쓰기 버튼 등 현재 버튼의 애니메이션이 다 작업된 것은 아닙니다. 요 작업은 이후에 바로 하겠습니다.
