### PR TITLE
폴더 내 리스트 구성하는 아이템 컴포넌트 추가 (#62)

### DIFF
--- a/components/Common/ChipButton/ChipButton.stories.tsx
+++ b/components/Common/ChipButton/ChipButton.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 
 import ChipButton, { ChipButtonProps } from './ChipButton';
 
@@ -14,7 +13,5 @@ const Template: Story<ChipButtonProps> = (args) => <ChipButton {...args} />;
 export const Default = Template.bind({});
 
 Default.args = {
-  children: '#Button Example',
-  canDelete: false,
-  onDelete: action('delete the tag'),
+  children: '모르겠어요',
 };

--- a/components/Common/ChipButton/ChipButton.tsx
+++ b/components/Common/ChipButton/ChipButton.tsx
@@ -1,32 +1,30 @@
-import React, { MouseEventHandler } from 'react';
-import CloseIcon from 'public/svgs/close.svg';
-import { ChipButtonContainer, Text, CloseImage } from './ChipButton.styles';
+import theme from '@/styles/theme';
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
 
 export interface ChipButtonProps {
-  canDelete: boolean;
-  onDelete: MouseEventHandler<HTMLImageElement>;
-  children: React.ReactNode;
+  bgColor?: string;
+  children: ReactNode;
 }
 
 const ChipButton = ({
-  canDelete = false,
-  onDelete,
+  bgColor = theme.colors.gray3,
   children,
 }: ChipButtonProps): React.ReactElement => {
   return (
-    <ChipButtonContainer>
-      <Text canDelete={canDelete}>{children}</Text>
-      {canDelete && (
-        <CloseImage
-          src={CloseIcon}
-          alt="삭제"
-          width={16}
-          height={16}
-          onClick={onDelete}
-        />
-      )}
-    </ChipButtonContainer>
+    <ChipButtonContainer bgColor={bgColor}>{children}</ChipButtonContainer>
   );
 };
+
+const ChipButtonContainer = styled.div<{ bgColor: string }>`
+  display: inline-flex;
+  align-items: center;
+  height: 3.2rem;
+  padding: 0 1.6rem;
+  background-color: ${(props) => props.bgColor};
+  border-radius: 1rem;
+  ${theme.fonts.h4};
+  color: ${theme.colors.white};
+`;
 
 export default ChipButton;

--- a/components/Common/TagButton/TagButton.stories.tsx
+++ b/components/Common/TagButton/TagButton.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import TagButton, { TagButtonProps } from './TagButton';
+
+export default {
+  component: TagButton,
+  title: 'TagButton',
+} as Meta;
+
+const Template: Story<TagButtonProps> = (args) => <TagButton {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  children: '#Button Example',
+  canDelete: false,
+  onDelete: action('delete the tag'),
+};

--- a/components/Common/TagButton/TagButton.stories.tsx
+++ b/components/Common/TagButton/TagButton.stories.tsx
@@ -16,5 +16,5 @@ export const Default = Template.bind({});
 Default.args = {
   children: '#Button Example',
   canDelete: false,
-  onDelete: action('delete the tag'),
+  onClick: action('delete the tag'),
 };

--- a/components/Common/TagButton/TagButton.styles.ts
+++ b/components/Common/TagButton/TagButton.styles.ts
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components';
 import Image from 'next/image';
 import theme from '@/styles/theme';
 
-export const ChipButtonContainer = styled.div`
+export const TagButtonContainer = styled.div`
   display: inline-flex;
   padding: 6px 14px;
   border: 1px solid ${theme.colors.gray6};

--- a/components/Common/TagButton/TagButton.tsx
+++ b/components/Common/TagButton/TagButton.tsx
@@ -4,13 +4,13 @@ import { TagButtonContainer, Text, CloseImage } from './TagButton.styles';
 
 export interface TagButtonProps {
   canDelete?: boolean;
-  onDelete?: MouseEventHandler<HTMLImageElement>;
+  onClick?: MouseEventHandler<HTMLImageElement>;
   children: React.ReactNode;
 }
 
 const TagButton = ({
   canDelete = false,
-  onDelete,
+  onClick,
   children,
 }: TagButtonProps): React.ReactElement => {
   return (
@@ -22,7 +22,7 @@ const TagButton = ({
           alt="삭제"
           width={16}
           height={16}
-          onClick={onDelete}
+          onClick={onClick}
         />
       )}
     </TagButtonContainer>

--- a/components/Common/TagButton/TagButton.tsx
+++ b/components/Common/TagButton/TagButton.tsx
@@ -1,0 +1,32 @@
+import React, { MouseEventHandler } from 'react';
+import CloseIcon from 'public/svgs/close.svg';
+import { TagButtonContainer, Text, CloseImage } from './TagButton.styles';
+
+export interface TagButtonProps {
+  canDelete?: boolean;
+  onDelete?: MouseEventHandler<HTMLImageElement>;
+  children: React.ReactNode;
+}
+
+const TagButton = ({
+  canDelete = false,
+  onDelete,
+  children,
+}: TagButtonProps): React.ReactElement => {
+  return (
+    <TagButtonContainer>
+      <Text canDelete={canDelete}>{children}</Text>
+      {canDelete && (
+        <CloseImage
+          src={CloseIcon}
+          alt="삭제"
+          width={16}
+          height={16}
+          onClick={onDelete}
+        />
+      )}
+    </TagButtonContainer>
+  );
+};
+
+export default TagButton;

--- a/components/Common/index.tsx
+++ b/components/Common/index.tsx
@@ -8,3 +8,4 @@ export { default as CommonHeader } from './Header/Header';
 export { default as CommonToast } from './Toast/Toast';
 export { default as CommonToggle } from './Toggle/Toggle';
 export { default as CommonWritingButton } from './WritingButton/WritingButton';
+export { default as CommonTagButton } from './TagButton/TagButton';

--- a/components/Post/PostItem.tsx/PostItem.stories.tsx
+++ b/components/Post/PostItem.tsx/PostItem.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+
+import PostItem, { PostItemProps } from './PostItem';
+
+export default {
+  component: PostItem,
+  title: 'PostItem',
+} as Meta;
+
+const Template: Story<PostItemProps> = (args) => <PostItem {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  post: {
+    firstCategory: '모르겠어요',
+    secondCategory: '기쁨',
+    content:
+      '안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.',
+    hit: 10,
+    createdAt: '날짜',
+    tags: ['5조', '작업하는 중..'],
+  },
+};

--- a/components/Post/PostItem.tsx/PostItem.tsx
+++ b/components/Post/PostItem.tsx/PostItem.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import styled from 'styled-components';
+import Image from 'next/image';
+import theme from '@/styles/theme';
+import { ellipsis } from '@/styles/mixins';
+import { CommonChipButton, CommonTagButton } from '@/components/Common';
+import ArrowRightIcon from 'public/svgs/arrowright.svg';
+import { Post } from '@/shared/type/post';
+
+export interface PostItemProps {
+  post: Post;
+  supportsTag?: boolean;
+  canEdit?: boolean;
+}
+
+const PostItem = ({
+  post,
+  supportsTag = false,
+  canEdit = false,
+}: PostItemProps): React.ReactElement => {
+  return (
+    <PostItemContainer>
+      {supportsTag && (
+        <TagList>
+          {post.tags.map((tag: string) => (
+            <CommonTagButton key={tag}>#{tag}</CommonTagButton>
+          ))}
+        </TagList>
+      )}
+      <ChipContainer>
+        <HighlightButton>MY</HighlightButton>
+        <CommonChipButton>{post.firstCategory}</CommonChipButton>
+        <Arrow>
+          <Image src={ArrowRightIcon} alt="" width={16} height={16} />
+        </Arrow>
+        <CommonChipButton>{post.secondCategory}</CommonChipButton>
+      </ChipContainer>
+      <Content>{post.content}</Content>
+      <CaptionContainer>
+        <Caption>{post.createdAt}</Caption>
+        <Caption>조회수 {post.hit}</Caption>
+      </CaptionContainer>
+    </PostItemContainer>
+  );
+};
+
+const PostItemContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 1.6rem 1.8rem;
+  border-radius: 1.4rem;
+  background-color: ${theme.colors.gray2};
+`;
+
+const TagList = styled.div`
+  display: flex;
+  margin-bottom: 2.4rem;
+
+  div ~ div {
+    margin-left: 1.2rem;
+  }
+`;
+
+const Content = styled.p`
+  ${ellipsis(2)};
+  ${theme.fonts.body};
+  margin: 1.8rem 0 2rem;
+  color: ${theme.colors.white};
+`;
+
+const ChipContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Arrow = styled.i`
+  margin: 0 0.8rem;
+`;
+
+const CaptionContainer = styled.div`
+  margin-left: auto;
+`;
+
+const Caption = styled.span`
+  ${theme.fonts.caption1};
+  color: ${theme.colors.gray4};
+
+  & ~ & {
+    margin-left: 1.6rem;
+  }
+`;
+
+const HighlightButton = styled.button`
+  ${theme.fonts.caption1};
+  margin-right: 1.2rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 1.1rem;
+  background-color: ${theme.colors.primary};
+  color: ${theme.colors.black};
+`;
+
+export default PostItem;

--- a/components/Post/PostItem.tsx/PostItem.tsx
+++ b/components/Post/PostItem.tsx/PostItem.tsx
@@ -14,7 +14,7 @@ export interface PostItemProps {
 }
 
 const PostItem = ({
-  post,
+  post: { tags, firstCategory, secondCategory, content, createdAt, hit },
   supportsTag = false,
   canEdit = false,
 }: PostItemProps): React.ReactElement => {
@@ -22,23 +22,23 @@ const PostItem = ({
     <PostItemContainer>
       {supportsTag && (
         <TagList>
-          {post.tags.map((tag: string) => (
-            <CommonTagButton key={tag}>#{tag}</CommonTagButton>
+          {tags.map((tag: string, index: number) => (
+            <CommonTagButton key={index}>#{tag}</CommonTagButton>
           ))}
         </TagList>
       )}
       <ChipContainer>
         <HighlightButton>MY</HighlightButton>
-        <CommonChipButton>{post.firstCategory}</CommonChipButton>
+        <CommonChipButton>{firstCategory}</CommonChipButton>
         <Arrow>
           <Image src={ArrowRightIcon} alt="" width={16} height={16} />
         </Arrow>
-        <CommonChipButton>{post.secondCategory}</CommonChipButton>
+        <CommonChipButton>{secondCategory}</CommonChipButton>
       </ChipContainer>
-      <Content>{post.content}</Content>
+      <Content>{content}</Content>
       <CaptionContainer>
-        <Caption>{post.createdAt}</Caption>
-        <Caption>조회수 {post.hit}</Caption>
+        <Caption>{createdAt}</Caption>
+        <Caption>조회수 {hit}</Caption>
       </CaptionContainer>
     </PostItemContainer>
   );

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -1,7 +1,74 @@
 import React from 'react';
+import WritingButon from '@/components/Common/WritingButton/WritingButton';
+import { useRouter } from 'next/router';
+import PostItem from '@/components/Post/PostItem.tsx/PostItem';
+import styled from 'styled-components';
+
+const postList = [
+  {
+    id: 1,
+    tags: ['짜증나', '태그', '테스트'],
+    firstCategory: '모르겠어요',
+    secondCategory: '기쁨',
+    content:
+      '안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요',
+    hit: 11,
+    createdAt: '2022-05-04',
+  },
+  {
+    id: 2,
+    tags: ['짜증나', '태그', '테스트'],
+    firstCategory: '모르겠어요',
+    secondCategory: '기쁨',
+    content:
+      '안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요',
+    hit: 11,
+    createdAt: '2022-05-04',
+  },
+  {
+    id: 3,
+    tags: ['짜증나', '태그', '테스트'],
+    firstCategory: '모르겠어요',
+    secondCategory: '기쁨',
+    content:
+      '안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요',
+    hit: 11,
+    createdAt: '2022-05-04',
+  },
+  {
+    id: 4,
+    tags: ['짜증나', '태그', '테스트'],
+    firstCategory: '모르겠어요',
+    secondCategory: '기쁨',
+    content:
+      '안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요안녕하세요.안녕하세요',
+    hit: 11,
+    createdAt: '2022-05-04',
+  },
+];
 
 const PostList = () => {
-  return <div>글 목록 페이지</div>;
+  const router = useRouter();
+  const handleWritingButton = () => router.push('/write/pre-emotion');
+
+  return (
+    <PostListContainer>
+      {postList.map((post) => (
+        <li key={post.id}>
+          <PostItem post={post} />
+        </li>
+      ))}
+      <WritingButon onClick={handleWritingButton} />
+    </PostListContainer>
+  );
 };
+
+const PostListContainer = styled.ul`
+  margin-top: 2rem;
+
+  li ~ li {
+    margin-top: 1.8rem;
+  }
+`;
 
 export default PostList;

--- a/public/svgs/arrowright.svg
+++ b/public/svgs/arrowright.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.5 8H13.5" stroke="#F2F2F2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 3.5L13.5 8L9 12.5" stroke="#F2F2F2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/shared/type/post.ts
+++ b/shared/type/post.ts
@@ -1,0 +1,8 @@
+export interface Post {
+  tags: string[];
+  firstCategory: string;
+  secondCategory: string;
+  content: string;
+  hit: number;
+  createdAt: string;
+}

--- a/styles/mixins.ts
+++ b/styles/mixins.ts
@@ -26,7 +26,7 @@ const ellipsis = (lines = 0) => {
         display: -webkit-box;
         overflow: hidden;
         -webkit-box-orient: vertical;
-        -webkit-line-clamp: $lines;
+        -webkit-line-clamp: ${lines};
         text-overflow: ellipsis;
         word-wrap: normal;
       `


### PR DESCRIPTION
## Description

Fixes (issue #62)

## Changes

**디자인 시스템**
- 기존 ChipButton -> TagButton 로 컴포넌트 네이밍 정정했습니다.
- ChipButton 컴포넌트, stories 추가하였습니다.

**페이지 내 컴포넌트**
- PostItem 컴포넌트 추가
  - /search 와 /posts 에서 사용할 수 있게 supportsTag, canEdit props 를 추가하였습니다.
- PostItem stories 추가
- /posts 페이지 기본 구성

**버그 수정**
- ellipsis mixins 내 Expression interpolation 을 잘못 작성해서 수정했습니다.

## 스크린샷

**감정 관련 Chip Button**
<img width="152" alt="스크린샷 2022-05-04 오전 12 21 30" src="https://user-images.githubusercontent.com/29244798/166488661-059b0e37-25c9-4072-93a4-9a1cfa693932.png">

**태그 있는 PostItem - 검색 페이지에서 사용**
<img width="371" alt="스크린샷 2022-05-04 오전 12 19 05" src="https://user-images.githubusercontent.com/29244798/166488684-4425cb3c-923a-4dec-b5d0-5a745e28762d.png">

**태그 없는 PostItem - 폴더 내 리스트 페이지에서 사용**
<img width="602" alt="스크린샷 2022-05-04 오전 12 18 48" src="https://user-images.githubusercontent.com/29244798/166488680-6553189d-44af-4c49-bd3b-4d3314172b16.png">

**폴더 내 리스트 기본 구성 - 예제**
<img width="373" alt="스크린샷 2022-05-04 오전 12 30 52" src="https://user-images.githubusercontent.com/29244798/166488667-b6bd473a-ccf6-48d2-829d-24fd23b7ae86.png">

## Checklist

- [ ] API spec 보고 내 글인지 아닌지에 대한 **MY** 엘리먼트 분기 처리 예정

한 컴포넌트를 구성하려고 조금씩 추가하다보니 PR 이 조금 커진 것 같네요..!ㅠㅠ..