### PR TITLE
메인페이지 - 폴더 리스트 UI API 연동 with msw (#23)

### DIFF
--- a/components/Common/AppLayout/AppLayout.styles.ts
+++ b/components/Common/AppLayout/AppLayout.styles.ts
@@ -8,9 +8,9 @@ export const ContainerInner = styled.div`
   display: flex;
   flex-direction: column;
   background-color: ${theme.colors.black};
-  max-width: 480px;
+  max-width: 48rem;
   width: 100%;
   min-height: 100vh;
   margin: 0 auto;
-  padding: 0 18px;
+  padding: 0 1.8rem 8rem;
 `;

--- a/components/Home/CollectedFolder/CollectedFolder.styles.ts
+++ b/components/Home/CollectedFolder/CollectedFolder.styles.ts
@@ -23,12 +23,14 @@ export const FolderCount = styled.span`
 export const BoxContainer = styled.figure`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 4px;
-  height: calc(100% - 42px);
+  gap: 0.4rem;
+  height: calc(100% - 4.2rem);
+  min-height: 16.5rem;
 `;
 
 export const FolderImage = styled.div<{ thumbnail: string }>`
-  border-radius: 10px;
-  background-image: url(thumbnail);
+  max-height: 50%;
+  border-radius: 1rem;
+  background-image: url(${(props) => props.thumbnail});
   background-color: ${theme.colors.gray3};
 `;

--- a/components/Home/CollectedFolder/CollectedFolder.tsx
+++ b/components/Home/CollectedFolder/CollectedFolder.tsx
@@ -7,7 +7,7 @@ import {
   BoxContainer,
   FolderImage,
 } from './CollectedFolder.styles';
-import { Folder } from '../Folder/Folder';
+import { Folder } from '@/shared/type/folder';
 import { MAX_THUMBNAIL_SIZE } from '@/shared/constants/home';
 
 // TODO: 이후 mocking 추가하면서 알맞는 폴더에 위치할 예정
@@ -24,7 +24,7 @@ const CollectedFolder = ({
     <CollectedFolderContainer>
       <BoxContainer>
         {items.slice(0, MAX_THUMBNAIL_SIZE).map((item) => (
-          <FolderImage key={item.name} thumbnail={item.thumbnail} />
+          <FolderImage key={item.folderId} thumbnail={item.coverImg} />
         ))}
       </BoxContainer>
       <Caption>

--- a/components/Home/Folder/Folder.styles.ts
+++ b/components/Home/Folder/Folder.styles.ts
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 import theme from '@/styles/theme';
 
-export const FolderContainer = styled.figure`
+export const FolderContainer = styled.div`
   position: relative;
   width: 100%;
-  height: 100%;
+  height: 16.5rem;
 `;
 
 export const FolderName = styled.p`
@@ -18,8 +18,14 @@ export const FolderCount = styled.span`
   color: ${theme.colors.gray4};
 `;
 
-export const BoxContainer = styled.figure`
+export const BoxContainer = styled.div`
   display: flex;
+  width: 100%;
+  height: 100%;
+
+  span {
+    border-radius: 1.4rem;
+  }
 `;
 
 export const CaptionContainer = styled.figcaption`

--- a/components/Home/Folder/Folder.tsx
+++ b/components/Home/Folder/Folder.tsx
@@ -9,31 +9,25 @@ import {
   BoxContainer,
   CaptionContainer,
 } from './Folder.styles';
+import { Folder } from '@/shared/type/folder';
 import EmptyImage from 'public/images/empty.png';
 import TrashIcon from 'public/svgs/trash.svg';
 import EditFolderIcon from 'public/svgs/editfolder.svg';
 
-export interface Folder {
-  name: string;
-  count: number;
-  thumbnail: string;
-}
-
-export interface FolderProps extends Folder {
+export interface FolderProps {
   isEditMode?: boolean;
   supportsMultipleLayout?: boolean;
+  folder: Folder;
 }
 
 const Folder = ({
-  name,
-  count,
-  thumbnail = '',
+  folder: { postCount, folderName, coverImg },
   isEditMode = false,
 }: FolderProps): React.ReactElement => {
   const renderDeleteButton = () => {
     return (
       <DeleteButton onClick={() => console.log('delete')}>
-        <Image src={TrashIcon} alt="삭제" />
+        <Image src={TrashIcon} alt="삭제" width={24} height={24} />
       </DeleteButton>
     );
   };
@@ -41,7 +35,7 @@ const Folder = ({
   const renderEditButton = () => {
     return (
       <EditButton onClick={() => console.log('edit')}>
-        <Image src={EditFolderIcon} alt="편집" />
+        <Image src={EditFolderIcon} alt="편집" width={24} height={24} />
       </EditButton>
     );
   };
@@ -49,18 +43,28 @@ const Folder = ({
   return (
     <FolderContainer>
       <BoxContainer>
-        {count === 0 ? (
-          <Image src={EmptyImage} alt="기록이 없어요" />
+        {postCount === 0 ? (
+          <Image
+            src={EmptyImage}
+            alt="기록이 없어요"
+            layout="fill"
+            objectFit="cover"
+          />
         ) : (
-          <Image src={thumbnail || EmptyImage} alt={name} />
+          <Image
+            src={coverImg || EmptyImage}
+            alt={folderName}
+            layout="fill"
+            objectFit="cover"
+          />
         )}
         {isEditMode && renderDeleteButton()}
       </BoxContainer>
       <CaptionContainer>
         {isEditMode && renderEditButton()}
         <div>
-          <FolderName>{name}</FolderName>
-          <FolderCount>{count}</FolderCount>
+          <FolderName>{folderName}</FolderName>
+          <FolderCount>{postCount}</FolderCount>
         </div>
       </CaptionContainer>
     </FolderContainer>

--- a/components/Home/FolderList/FolderList.tsx
+++ b/components/Home/FolderList/FolderList.tsx
@@ -1,70 +1,27 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Folder } from '@/shared/type/folder';
 import HomeFolder from '@/components/Home/Folder/Folder';
 import HomeCollectedFolder from '@/components/Home/CollectedFolder/CollectedFolder';
 
 interface FolderListProps {
   isEditMode: boolean;
+  folderList: Folder[];
 }
 
-const FolderList = ({ isEditMode }: FolderListProps): React.ReactElement => {
-  const folderList = [
-    {
-      name: '폴더명1',
-      count: 3,
-      thumbnail: '',
-    },
-    {
-      name: '폴더명2',
-      count: 3,
-      thumbnail: '',
-    },
-    {
-      name: '폴더명3',
-      count: 3,
-      thumbnail: '',
-    },
-    {
-      name: '폴더명4',
-      count: 3,
-      thumbnail: '',
-    },
-    {
-      name: '폴더명5',
-      count: 3,
-      thumbnail: '',
-    },
-    {
-      name: '폴더명6',
-      count: 3,
-      thumbnail: '',
-    },
-    {
-      name: '폴더명7',
-      count: 3,
-      thumbnail: '',
-    },
-    {
-      name: '폴더명8',
-      count: 3,
-      thumbnail: '',
-    },
-    {
-      name: '폴더명9',
-      count: 3,
-      thumbnail: '',
-    },
-  ];
+const FolderList = ({
+  isEditMode,
+  folderList,
+}: FolderListProps): React.ReactElement => {
+  const totalCount = folderList.reduce((acc, curr) => acc + curr.postCount, 0);
 
   return (
     <FolderListContainer>
-      <HomeCollectedFolder count={3} items={folderList} />
-      {folderList.map((folder) => (
+      <HomeCollectedFolder count={totalCount} items={folderList} />
+      {folderList.map((folder: Folder) => (
         <HomeFolder
-          key={folder.name}
-          name="폴더명"
-          count={folder.count}
-          thumbnail=""
+          key={folder.folderId}
+          folder={folder}
           isEditMode={isEditMode}
         />
       ))}

--- a/hooks/query/useFoldersQuery.ts
+++ b/hooks/query/useFoldersQuery.ts
@@ -1,0 +1,23 @@
+import Error from 'next/error';
+import { useQuery } from 'react-query';
+import { apiClient } from '@/shared/api/apiClient';
+import { QUERY_KEY } from '@/shared/constants/queryKey';
+import { Folder } from '@/shared/type/folder';
+
+interface FolderResponse {
+  folders: Folder[];
+  postsThumbnail: string[];
+}
+const fetchFolders = async (): Promise<FolderResponse> => {
+  const {
+    data: { data },
+  } = await apiClient.get('/folders');
+
+  return data;
+};
+
+const useFoldersQuery = () => {
+  return useQuery<FolderResponse, Error>(QUERY_KEY.GET_FOLDERS, fetchFolders);
+};
+
+export { useFoldersQuery, fetchFolders };

--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,9 @@ module.exports = {
   compiler: {
     styledComponents: true,
   },
+  images: {
+    domains: ['firebasestorage.googleapis.com'],
+  },
   webpack(config) {
     return config;
   },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,6 +15,7 @@ import {
   CommonWritingButton,
 } from '@/components/Common';
 import DialogFolderForm from '@/components/Dialog/DialogFolderForm';
+import { useFoldersQuery } from '@/hooks/query/useFoldersQuery';
 
 const Home = () => {
   const router = useRouter();
@@ -24,6 +25,7 @@ const Home = () => {
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
   const { dialogVisible, toggleDialog } = useDialog();
   const { inputValue, onChangeInput } = useInput('');
+  const { data } = useFoldersQuery();
 
   const goToUndefinedFeelings = () => {
     router.push('/posts/undefined-feelings');
@@ -44,7 +46,7 @@ const Home = () => {
         setCurrentTab={handleCurrentTab}
         onClick={toggleDialog}
       />
-      <FolderList isEditMode={isEditMode} />
+      {data && <FolderList isEditMode={isEditMode} folderList={data.folders} />}
       <CommonWritingButton onClick={() => router.push('/write/pre-emotion')} />
       <FloatingContainer>
         <div>

--- a/shared/constants/queryKey.ts
+++ b/shared/constants/queryKey.ts
@@ -1,3 +1,4 @@
 export const QUERY_KEY = {
   GET_POSTS: 'GET_POSTS',
+  GET_FOLDERS: 'GET_FOLDERS',
 } as const;

--- a/shared/type/folder.ts
+++ b/shared/type/folder.ts
@@ -1,0 +1,6 @@
+export interface Folder {
+  folderId: number;
+  folderName: string;
+  coverImg: string;
+  postCount: number;
+}


### PR DESCRIPTION
## Description

Feature(#23)

## Changes

메인페이지 폴더별 리스트 페이지를 mocking 한 api 호출해서 작업해보았습니다!

**개발 내용**
- GET_FOLDER queryKey 추가
- Folder interface 추가
- useFoldersQuery hooks 추가
- next.config.js 에 images.domain 추가
  - 현재 API mock data 에 있는 firebasestorage.googleapis.com 를 추가했습니다!

## 스크린샷

<img width="410" alt="스크린샷 2022-05-07 오후 10 00 15" src="https://user-images.githubusercontent.com/29244798/167255580-f4ed99da-fe94-432f-b113-1a99c141cbb3.png">
