### PR TITLE
폴더 내 리스트 페이지 추가 기능 작업 (#63)

### DIFF
--- a/components/Common/Checkbox/Checkbox.tsx
+++ b/components/Common/Checkbox/Checkbox.tsx
@@ -5,7 +5,7 @@ import { ReactNode, ChangeEventHandler } from 'react';
 
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   name: string;
-  value: string;
+  value: string | number;
   checked: boolean;
   children?: ReactNode;
   onChange?: ChangeEventHandler<HTMLInputElement>;

--- a/components/Dialog/DialogFolderForm.tsx
+++ b/components/Dialog/DialogFolderForm.tsx
@@ -4,14 +4,21 @@ import theme from '@/styles/theme';
 import { CommonTextField } from '../Common';
 
 interface DialogFolderFormProps {
+  isEditMode?: boolean;
   value: string;
   onChange: ChangeEventHandler<HTMLInputElement>;
 }
 
-const DialogFolderForm = ({ value, onChange }: DialogFolderFormProps) => {
+const DialogFolderForm = ({
+  isEditMode = false,
+  value,
+  onChange,
+}: DialogFolderFormProps) => {
+  const dialogTitle = isEditMode ? '변경할 폴더를' : '새폴더의 이름을';
+
   return (
     <DialogContainer>
-      <Title>📁 새폴더의 이름을 입력해주세요.</Title>
+      <Title>📁 {dialogTitle} 입력해주세요.</Title>
       <CommonTextField
         placeholder="폴더명 입력"
         borderRadius="0.4rem"

--- a/components/Home/CollectedFolder/CollectedFolder.styles.ts
+++ b/components/Home/CollectedFolder/CollectedFolder.styles.ts
@@ -3,6 +3,7 @@ import theme from '@/styles/theme';
 
 export const CollectedFolderContainer = styled.figure`
   width: 100%;
+  cursor: pointer;
 `;
 
 export const Caption = styled.figcaption`

--- a/components/Home/CollectedFolder/CollectedFolder.tsx
+++ b/components/Home/CollectedFolder/CollectedFolder.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { HtmlHTMLAttributes } from 'react';
 import {
   CollectedFolderContainer,
   Caption,
@@ -11,7 +11,8 @@ import { Folder } from '@/shared/type/folder';
 import { MAX_THUMBNAIL_SIZE } from '@/shared/constants/home';
 
 // TODO: 이후 mocking 추가하면서 알맞는 폴더에 위치할 예정
-export interface CollectedFolderProps {
+export interface CollectedFolderProps
+  extends HtmlHTMLAttributes<HTMLDivElement> {
   count: number;
   items: Folder[];
 }
@@ -19,9 +20,10 @@ export interface CollectedFolderProps {
 const CollectedFolder = ({
   count,
   items,
+  ...rest
 }: CollectedFolderProps): React.ReactElement => {
   return (
-    <CollectedFolderContainer>
+    <CollectedFolderContainer {...rest}>
       <BoxContainer>
         {items.slice(0, MAX_THUMBNAIL_SIZE).map((item) => (
           <FolderImage key={item.folderId} thumbnail={item.coverImg} />

--- a/components/Home/Folder/Folder.styles.ts
+++ b/components/Home/Folder/Folder.styles.ts
@@ -5,6 +5,7 @@ export const FolderContainer = styled.div`
   position: relative;
   width: 100%;
   height: 16.5rem;
+  cursor: pointer;
 `;
 
 export const FolderName = styled.p`

--- a/components/Home/Folder/Folder.tsx
+++ b/components/Home/Folder/Folder.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { HtmlHTMLAttributes } from 'react';
 import Image from 'next/image';
 import {
   FolderContainer,
@@ -14,7 +14,7 @@ import EmptyImage from 'public/images/empty.png';
 import TrashIcon from 'public/svgs/trash.svg';
 import EditFolderIcon from 'public/svgs/editfolder.svg';
 
-export interface FolderProps {
+export interface FolderProps extends HtmlHTMLAttributes<HTMLDivElement> {
   isEditMode?: boolean;
   supportsMultipleLayout?: boolean;
   folder: Folder;
@@ -23,6 +23,7 @@ export interface FolderProps {
 const Folder = ({
   folder: { postCount, folderName, coverImg },
   isEditMode = false,
+  ...rest
 }: FolderProps): React.ReactElement => {
   const renderDeleteButton = () => {
     return (
@@ -41,7 +42,7 @@ const Folder = ({
   };
 
   return (
-    <FolderContainer>
+    <FolderContainer {...rest}>
       <BoxContainer>
         {postCount === 0 ? (
           <Image

--- a/components/Home/FolderList/FolderList.tsx
+++ b/components/Home/FolderList/FolderList.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Folder } from '@/shared/type/folder';
 import HomeFolder from '@/components/Home/Folder/Folder';
 import HomeCollectedFolder from '@/components/Home/CollectedFolder/CollectedFolder';
+import { useRouter } from 'next/router';
 
 interface FolderListProps {
   isEditMode: boolean;
@@ -13,18 +14,30 @@ interface FolderListProps {
 const FolderList = ({
   isEditMode,
   folderList,
-  supportsCollectedFolder
+  supportsCollectedFolder,
 }: FolderListProps): React.ReactElement => {
+  const router = useRouter();
   const totalCount = folderList.reduce((acc, curr) => acc + curr.postCount, 0);
+
+  const goToPosts = () => {
+    router.push('/posts');
+  };
 
   return (
     <FolderListContainer>
-      {supportsCollectedFolder && <HomeCollectedFolder count={totalCount} items={folderList} />}
+      {supportsCollectedFolder && (
+        <HomeCollectedFolder
+          count={totalCount}
+          items={folderList}
+          onClick={goToPosts}
+        />
+      )}
       {folderList.map((folder: Folder) => (
         <HomeFolder
           key={folder.folderId}
           folder={folder}
           isEditMode={isEditMode}
+          onClick={() => router.push(`/posts?folderId=${folder.folderId}`)}
         />
       ))}
     </FolderListContainer>

--- a/components/Post/PostItem/PostItem.tsx
+++ b/components/Post/PostItem/PostItem.tsx
@@ -22,7 +22,7 @@ export interface PostItemProps {
 }
 
 const PostItem = ({
-  post: { tags, firstCategory, secondCategory, content, createdAt, hit },
+  post: { id, tags, firstCategory, secondCategory, content, createdAt, hit },
   supportsTag = false,
   canEdit = false,
   isMine = false,
@@ -35,7 +35,7 @@ const PostItem = ({
       {isEditing && (
         <>
           <CheckboxContainer>
-            <CommonCheckbox name="체크" value="체크" checked={checked} />
+            <CommonCheckbox name="checkbox" value={id} checked={checked} />
           </CheckboxContainer>
           <Dimmed checked={checked} />
         </>

--- a/components/Post/PostList/PostList.tsx
+++ b/components/Post/PostList/PostList.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import styled from 'styled-components';
+import PostItem from '@/components/Post/PostItem/PostItem';
+import { Post } from '@/shared/type/post';
+
+interface PostListProps {
+  postList: Post[];
+  isEditing: boolean;
+  checkedItems: number[];
+  setCheckedItems: React.Dispatch<React.SetStateAction<number[]>>;
+}
+
+const PostList = ({
+  postList,
+  isEditing,
+  checkedItems,
+  setCheckedItems,
+}: PostListProps) => {
+  const router = useRouter();
+
+  const changeCheckedItems = (postId: number) => {
+    if (checkedItems.includes(postId)) {
+      setCheckedItems(checkedItems.filter((item) => item !== postId));
+      return;
+    }
+
+    return setCheckedItems([...checkedItems, postId]);
+  };
+
+  const handlePostItemClick = (postId: number) => {
+    if (!isEditing) {
+      return router.push(`/posts/${postId}`);
+    }
+
+    changeCheckedItems(postId);
+  };
+
+  const isChecked = (checkedId: number) => checkedItems.includes(checkedId);
+
+  return (
+    <PostListContainer>
+      {postList.map((post) => (
+        <li key={post.id}>
+          <PostItem
+            {...{ post, isEditing }}
+            checked={isChecked(post.id)}
+            onClick={() => handlePostItemClick(post.id)}
+          />
+        </li>
+      ))}
+    </PostListContainer>
+  );
+};
+
+const PostListContainer = styled.ul`
+  margin-top: 2rem;
+
+  li ~ li {
+    margin-top: 1.8rem;
+  }
+`;
+
+export default PostList;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
+import Image from 'next/image';
 import { useSetRecoilState } from 'recoil';
 import { tooltipStateAtom } from '@/store/tooltip/atom';
 import { HOME_TAB_TYPE, CurrentTabType } from '@/shared/constants/home';
 import { transition } from '@/styles/mixins';
+import theme from '@/styles/theme';
 import useDialog from '@/hooks/useDialog';
 import useInput from '@/hooks/useInput';
+import { useFoldersQuery } from '@/hooks/query/useFoldersQuery';
 import HomeBanner from '@/components/Home/Banner/Banner';
 import HomeTabHeader from '@/components/Home/TabHeader/TabHeader';
 import HomeTabs from '@/components/Home/Tabs/Tabs';
@@ -18,7 +21,7 @@ import {
   CommonWritingButton,
 } from '@/components/Common';
 import DialogFolderForm from '@/components/Dialog/DialogFolderForm';
-import { useFoldersQuery } from '@/hooks/query/useFoldersQuery';
+import RightIcon from 'public/svgs/right-small.svg';
 
 const Home = () => {
   const router = useRouter();
@@ -62,12 +65,23 @@ const Home = () => {
         setCurrentTab={handleCurrentTab}
         onClick={toggleDialog}
       />
-      {data && <FolderList isEditMode={isEditMode} folderList={data.folders} supportsCollectedFolder={currentTab === HOME_TAB_TYPE.FOLDER} />}
+      {data && (
+        <FolderList
+          isEditMode={isEditMode}
+          folderList={data.folders}
+          supportsCollectedFolder={currentTab === HOME_TAB_TYPE.FOLDER}
+        />
+      )}
       <CommonWritingButton onClick={goToWritePage} />
       <FloatingContainer>
         <div>
           <CommonButton color="gray" onClick={goToUndefinedFeelings}>
-            지난 감정 되돌아보기
+            <ButtonText>
+              &apos;모르겠어요&apos;를 선택한 기록들
+              <ButtonIcon>
+                <Image src={RightIcon} alt="" />
+              </ButtonIcon>
+            </ButtonText>
           </CommonButton>
         </div>
       </FloatingContainer>
@@ -97,6 +111,20 @@ const FloatingContainer = styled.div`
     width: 22.3rem;
     margin: 0 auto;
   }
+`;
+
+const ButtonText = styled.span`
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 0 1.9rem 0 2.2rem;
+  ${theme.fonts.btn2};
+`;
+
+const ButtonIcon = styled.i`
+  position: absolute;
+  top: 0;
+  right: 1.9rem;
 `;
 
 export default Home;

--- a/public/svgs/right-small.svg
+++ b/public/svgs/right-small.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 2L11 8L5 14" stroke="#F2F2F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Description

Feature (issue #63)

폴더 내 리스트 페이지 추가 기능 작업

1. 폴더 삭제
2. 폴더명 변경
3. 기록 여러개 선택 (편집 모드)
4. 메인페이지 폴더 컴포넌트 선택 가능하게끔 변경

## Changes

**메인 페이지**
- Home/Folder, CollectedFolder 컴포넌트 cursor:pointer 스타일 적용, onClick props 전달하였습니다.

**폴더 내 리스트 페이지**
- PostList 컴포넌트 페이지 분리해서 PostList 페이지에서 `checkedItems` 핸들링할 수 있게 작업하였습니다.
- BottomSheet 에서 폴더 삭제, 폴더명 변경 다이얼로그 연결 작업하였습니다.

**Dialog**
- DialogFolderForm 컴포넌트에 `isEditMode` props 추가하여 다이얼로그 타이틀 동적으로 변경할 수 있게 하였습니다.

## 스크린샷

**여러개 기록 삭제를 위한 체크박스 선택**

https://user-images.githubusercontent.com/29244798/167448155-38e04c9f-9f4c-4eba-b70c-0a6522d6c5ca.mov

**폴더명 변경**

<img width="396" alt="스크린샷 2022-05-10 오전 12 35 36" src="https://user-images.githubusercontent.com/29244798/167448186-0865703b-6d54-4509-9b20-59bac61a6608.png">

**폴더 삭제**

<img width="396" alt="스크린샷 2022-05-10 오전 12 35 43" src="https://user-images.githubusercontent.com/29244798/167448189-76e58500-f976-4d01-a6a9-cd4ae8879846.png">

---

다음 작업 is .. 
- intersection observer
- 동일한 PostList 페이지에 folderId로 조회했을 때, categoryId로 조회했을 때에 대해 대응하는 작업을 해야겠습니다..!