### PR TITLE
상세페이지 bottom sheet 연결, bottom sheet animation 수정 (#102)

### DIFF
--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -18,7 +18,7 @@ const Card = ({
   return (
     <CardContainer firstColor={firstColor} secondColor={secondColor}>
       <ImageContainer>
-        <Image src={MoodBoard} alt="" />
+        <Image src={MoodBoard} alt="" height={144} />
       </ImageContainer>
       {children}
     </CardContainer>

--- a/components/Common/BottomSheetContainer/BottomSheetContainer.tsx
+++ b/components/Common/BottomSheetContainer/BottomSheetContainer.tsx
@@ -50,7 +50,7 @@ const BottomSheetContainer = ({
   return createPortal(
     <BottomSheetWrapper>
       <BottomSheetDimmed style={opacityAnimation} onClick={closeModal} />
-      <BottomSheetWrap>
+      <BottomSheetWrap onClick={closeModal}>
         <BottomSheetInner style={heightAnimation}>
           {headerTitle ? (
             <BottomSheetHeader>

--- a/components/Example/BottomSheetExample.tsx
+++ b/components/Example/BottomSheetExample.tsx
@@ -61,7 +61,9 @@ const BottomSheetExample = () => {
       {isVisibleSheet ? (
         <CommonBottomSheetContainer
           onClose={() => toggleSheet()}
-          BottomSheetHeight={calcBottomSheetHeight(folderDataLength)}
+          BottomSheetHeight={calcBottomSheetHeight({
+            folderSize: folderDataLength,
+          })}
           headerTitle={
             <>
               <Image src={FolderIcon} alt="folderIcon" />

--- a/components/Post/PostDetail.style.ts
+++ b/components/Post/PostDetail.style.ts
@@ -1,0 +1,54 @@
+import theme from '@/styles/theme';
+import styled from 'styled-components';
+import { ProvidedQuestionMainTitle } from '../Question/Question.styles';
+
+export const PostDetailContainer = styled.section`
+display: flex;
+flex-direction: column;
+padding-bottom: 8rem;
+`;
+
+export const TagContainer = styled.div`
+display: flex;
+overflow-x: auto;
+padding: 0 1.8rem;
+margin: 2rem -1.8rem 2.4rem;
+
+div {
+  flex: 1 0 auto;
+}
+
+div ~ div {
+  margin-left: 1.2rem;
+}
+
+&::-webkit-scrollbar {
+  display: none;
+}
+`;
+
+export const Description = styled.p`
+${theme.fonts.caption1};
+color: ${theme.colors.gray4};
+margin-left: auto;
+
+div ~ & {
+  margin-top: 1.4rem;
+}
+
+& ~ & {
+  margin-top: 1rem;
+}
+`;
+
+export const CardContainer = styled.div`
+margin-bottom: 2.4rem;
+`;
+
+export const MultipleLineText = styled(ProvidedQuestionMainTitle)`
+line-height: 160%;
+`;
+
+export const QuestionContainer = styled.div`
+margin-bottom: -2.6rem;
+`;

--- a/hooks/useAnimation.ts
+++ b/hooks/useAnimation.ts
@@ -9,14 +9,20 @@ interface SpringAnimationProps {
 export const useAnimation = ({ onClose, fullHeight }: SpringAnimationProps) => {
   const [isPrevClose, setPrevClose] = useState(false);
 
+  const setOverflowStyle = () => {
+    document.body.style.overflow = isPrevClose ? 'unset' : 'hidden';
+  };
+
   const opacityAnimation = useSpring({
     to: { opacity: isPrevClose ? 0 : 1 },
     from: { opacity: isPrevClose ? 1 : 0.6 },
     onRest: () => {
       isPrevClose && onClose();
+
+      setOverflowStyle();
     },
     onStart: () => {
-      document.body.style.overflow = isPrevClose ? 'unset' : 'hidden';
+      setOverflowStyle();
     },
   });
 

--- a/hooks/useBottomSheet.ts
+++ b/hooks/useBottomSheet.ts
@@ -8,14 +8,16 @@ const LIST_BOTTOM_HEIGHT = 58;
 export default function useBottomSheet() {
   const [isVisibleSheet, setVisibleSheet] = useState(false);
 
-  const calcBottomSheetHeight = (
-    folderDataLength: number,
-    hasHeader?: boolean,
-  ) => {
-    if (folderDataLength > MAX_SHOW_LIST_ITEM) return 530;
+  const calcBottomSheetHeight = ({
+    folderSize,
+    hasHeader,
+  }: {
+    folderSize: number;
+    hasHeader?: boolean;
+  }) => {
+    if (folderSize > MAX_SHOW_LIST_ITEM) return 530;
 
-    const contentHeight =
-      LIST_ITEM_HEIGHT * folderDataLength + LIST_BOTTOM_HEIGHT;
+    const contentHeight = LIST_ITEM_HEIGHT * folderSize + LIST_BOTTOM_HEIGHT;
     return hasHeader ? HEADER_HEIGHT + contentHeight : contentHeight;
   };
 

--- a/hooks/useBottomSheet.ts
+++ b/hooks/useBottomSheet.ts
@@ -8,11 +8,15 @@ const LIST_BOTTOM_HEIGHT = 58;
 export default function useBottomSheet() {
   const [isVisibleSheet, setVisibleSheet] = useState(false);
 
-  const calcBottomSheetHeight = (folderDataLength: number) => {
+  const calcBottomSheetHeight = (
+    folderDataLength: number,
+    hasHeader?: boolean,
+  ) => {
     if (folderDataLength > MAX_SHOW_LIST_ITEM) return 530;
-    return (
-      HEADER_HEIGHT + LIST_ITEM_HEIGHT * folderDataLength + LIST_BOTTOM_HEIGHT
-    );
+
+    const contentHeight =
+      LIST_ITEM_HEIGHT * folderDataLength + LIST_BOTTOM_HEIGHT;
+    return hasHeader ? HEADER_HEIGHT + contentHeight : contentHeight;
   };
 
   const toggleSheet = () => {

--- a/pages/posts/[postId].tsx
+++ b/pages/posts/[postId].tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { useRouter } from 'next/router';
-import styled from 'styled-components';
 import {
   CommonAppBar,
+  CommonBottomSheetContainer,
+  CommonDialog,
   CommonIconButton,
   CommonTagButton,
 } from '@/components/Common';
 import Card from '@/components/Card/Card';
-import theme from '@/styles/theme';
 import { EMOTION_COLOR_TYPE } from '@/shared/constants/emotion';
 import { CONTENT_SEPARATOR } from '@/shared/constants/question';
 import {
@@ -16,10 +16,35 @@ import {
   ProvidedQuestionWrap,
 } from '@/components/Question/Question.styles';
 import { CommonTextArea } from '@/components/Common';
+import useBottomSheet from '@/hooks/useBottomSheet';
+import useDialog from '@/hooks/useDialog';
+import BottomSheetList from '@/components/BottomSheetList/BottomSheetList';
+import DialogWarning from '@/components/Dialog/DialogWarning';
+import { PostDetailContainer, TagContainer, Description, CardContainer, MultipleLineText, QuestionContainer } from '@/components/Post/PostDetail.style';
 
 const PostDetail = () => {
   const router = useRouter();
   const { postId } = router.query;
+  const { dialogVisible, toggleDialog } = useDialog();
+  const { calcBottomSheetHeight, toggleSheet, isVisibleSheet } =
+    useBottomSheet();
+
+  const bottomSheetItems = [
+    {
+      label: '수정하기',
+      onClick: () => {
+        router.push(`/posts/${postId}/edit`);
+        toggleSheet();
+      },
+    },
+    {
+      label: '삭제하기',
+      onClick: () => {
+        toggleSheet();
+        toggleDialog();
+      },
+    },
+  ];
 
   const post = {
     id: 3,
@@ -35,15 +60,19 @@ const PostDetail = () => {
   const hasMultipleContent = post.content.includes(CONTENT_SEPARATOR);
   const contents = post.content.split(CONTENT_SEPARATOR);
 
+  const onDelete = () => {
+    console.log('폴더 삭제');
+  };
+
   return (
     <>
       <CommonAppBar>
         <CommonAppBar.Left>
-          <CommonIconButton iconName="left"></CommonIconButton>
+          <CommonIconButton iconName="left" onClick={() => router.back()} />
         </CommonAppBar.Left>
         <CommonAppBar.Right>
-          <CommonIconButton iconName="share"></CommonIconButton>
-          <CommonIconButton iconName="more"></CommonIconButton>
+          <CommonIconButton iconName="share" />
+          <CommonIconButton iconName="more" onClick={toggleSheet} />
         </CommonAppBar.Right>
       </CommonAppBar>
       <PostDetailContainer>
@@ -99,59 +128,24 @@ const PostDetail = () => {
         <Description>조회수 {post.hit}</Description>
         <Description>{post.createdAt}</Description>
       </PostDetailContainer>
+      {isVisibleSheet && (
+        <CommonBottomSheetContainer
+          onClose={() => toggleSheet()}
+          BottomSheetHeight={calcBottomSheetHeight(
+            bottomSheetItems.length,
+            false,
+          )}
+        >
+          <BottomSheetList items={bottomSheetItems} />
+        </CommonBottomSheetContainer>
+      )}
+      {dialogVisible && (
+        <CommonDialog type="alert" onClose={toggleDialog} onConfirm={onDelete}>
+          <DialogWarning>폴더를 삭제하시겠습니까?</DialogWarning>
+        </CommonDialog>
+      )}
     </>
   );
 };
-
-const PostDetailContainer = styled.section`
-  display: flex;
-  flex-direction: column;
-  padding-bottom: 8rem;
-`;
-
-const TagContainer = styled.div`
-  display: flex;
-  overflow-x: auto;
-  padding: 0 1.8rem;
-  margin: 2rem -1.8rem 2.4rem;
-
-  div {
-    flex: 1 0 auto;
-  }
-
-  div ~ div {
-    margin-left: 1.2rem;
-  }
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-`;
-
-const Description = styled.p`
-  ${theme.fonts.caption1};
-  color: ${theme.colors.gray4};
-  margin-left: auto;
-
-  div ~ & {
-    margin-top: 1.4rem;
-  }
-
-  & ~ & {
-    margin-top: 1rem;
-  }
-`;
-
-const CardContainer = styled.div`
-  margin-bottom: 2.4rem;
-`;
-
-const MultipleLineText = styled(ProvidedQuestionMainTitle)`
-  line-height: 160%;
-`;
-
-const QuestionContainer = styled.div`
-  margin-bottom: -2.6rem;
-`;
 
 export default PostDetail;

--- a/pages/posts/[postId].tsx
+++ b/pages/posts/[postId].tsx
@@ -20,7 +20,14 @@ import useBottomSheet from '@/hooks/useBottomSheet';
 import useDialog from '@/hooks/useDialog';
 import BottomSheetList from '@/components/BottomSheetList/BottomSheetList';
 import DialogWarning from '@/components/Dialog/DialogWarning';
-import { PostDetailContainer, TagContainer, Description, CardContainer, MultipleLineText, QuestionContainer } from '@/components/Post/PostDetail.style';
+import {
+  PostDetailContainer,
+  TagContainer,
+  Description,
+  CardContainer,
+  MultipleLineText,
+  QuestionContainer,
+} from '@/components/Post/PostDetail.style';
 
 const PostDetail = () => {
   const router = useRouter();
@@ -131,10 +138,10 @@ const PostDetail = () => {
       {isVisibleSheet && (
         <CommonBottomSheetContainer
           onClose={() => toggleSheet()}
-          BottomSheetHeight={calcBottomSheetHeight(
-            bottomSheetItems.length,
-            false,
-          )}
+          BottomSheetHeight={calcBottomSheetHeight({
+            folderSize: bottomSheetItems.length,
+            hasHeader: false,
+          })}
         >
           <BottomSheetList items={bottomSheetItems} />
         </CommonBottomSheetContainer>

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -141,10 +141,10 @@ const PostListPage = () => {
       {isVisibleSheet && (
         <CommonBottomSheetContainer
           onClose={() => toggleSheet()}
-          BottomSheetHeight={calcBottomSheetHeight(
-            bottomSheetItems.length,
-            false,
-          )}
+          BottomSheetHeight={calcBottomSheetHeight({
+            folderSize: bottomSheetItems.length,
+            hasHeader: false,
+          })}
         >
           <BottomSheetList items={bottomSheetItems} />
         </CommonBottomSheetContainer>

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -141,7 +141,10 @@ const PostListPage = () => {
       {isVisibleSheet && (
         <CommonBottomSheetContainer
           onClose={() => toggleSheet()}
-          BottomSheetHeight={calcBottomSheetHeight(bottomSheetItems.length)}
+          BottomSheetHeight={calcBottomSheetHeight(
+            bottomSheetItems.length,
+            false,
+          )}
         >
           <BottomSheetList items={bottomSheetItems} />
         </CommonBottomSheetContainer>


### PR DESCRIPTION
## Description

Fixes (issue #102)
상세페이지 bottom sheet 연결

## Changes

- Card background image height 수정
- bottom sheet animation 수정
  - bottom sheet 내부에 있는 버튼을 클릭 했을 때, bottom sheet 닫히고 body overflow hidden -> unset 으로 변경되지 않아서 closeModal 함수를 호출하게끔 하였습니다.

- 상세 페이지 헤더 버튼 클릭 시, bottom sheet 열리게끔 수정

## 스크린샷

<img width="417" alt="스크린샷 2022-05-14 오전 12 10 26" src="https://user-images.githubusercontent.com/29244798/168313503-47329d84-4e4c-4af4-bc73-b4d5d46b74ca.png">

<img width="420" alt="스크린샷 2022-05-14 오전 12 10 13" src="https://user-images.githubusercontent.com/29244798/168313534-45ee1d7e-d470-4f03-af7e-f5c137819a57.png">

