### PR TITLE
2차 감정 미선택 기록 페이지 작업 (#64)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,5 @@
   "useTabs": false,
   "tabWidth": 2,
   "trailingComma": "all",
-  "printWidth": 80
+  "printWidth": 120
 }

--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -10,11 +10,7 @@ export interface CardProps {
   children: React.ReactNode;
 }
 
-const Card = ({
-  firstColor,
-  secondColor,
-  children,
-}: CardProps): React.ReactElement => {
+const Card = ({ firstColor, secondColor, children }: CardProps): React.ReactElement => {
   return (
     <CardContainer firstColor={firstColor} secondColor={secondColor}>
       <ImageContainer>

--- a/components/Common/TextField/TextField.styles.ts
+++ b/components/Common/TextField/TextField.styles.ts
@@ -23,9 +23,7 @@ export const Container = styled.div<Pick<TextFieldProps, 'height'>>`
   flex: 0 1 auto;
 `;
 
-export const Input = styled.input<
-  Pick<TextFieldProps, 'borderRadius' | 'hasBorder' | 'height'>
->`
+export const Input = styled.input<Pick<TextFieldProps, 'borderRadius' | 'hasBorder' | 'height'>>`
   text-align: start;
   cursor: text;
   height: 100%;
@@ -58,7 +56,7 @@ export const RightSideIcon = styled.img<{ isFocused: boolean }>`
   ${(props) => IconStyle(props.isFocused)};
 `;
 
-export const Caption = styled.span`
+export const Caption = styled.p`
   margin: 0.4rem 0 0 auto;
   ${theme.fonts.caption1};
   color: ${theme.colors.gray4};

--- a/components/Common/TextField/TextField.tsx
+++ b/components/Common/TextField/TextField.tsx
@@ -1,13 +1,7 @@
 import React, { useState } from 'react';
-import {
-  Container,
-  Input,
-  Caption,
-  RightSideIcon,
-} from '@/components/Common/TextField/TextField.styles';
+import { Container, Input, Caption, RightSideIcon } from '@/components/Common/TextField/TextField.styles';
 
-export interface TextFieldProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface TextFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
   value: string;
   rightSideIcon?: string;
   height?: string;
@@ -33,36 +27,33 @@ const TextField = ({
   const [isFocused, setIsFocused] = useState(false);
 
   return (
-    <Container height={height}>
-      <Input
-        value={value}
-        borderRadius={borderRadius}
-        onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
-          setIsFocused(true);
-          onFocus?.(event);
-        }}
-        onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
-          setIsFocused(false);
-          onBlur?.(event);
-        }}
-        hasBorder={hasBorder}
-        maxLength={maxLength}
-        {...restTextFieldProps}
-      />
-      {rightSideIcon && (
-        <RightSideIcon
-          src={rightSideIcon}
-          alt="aside-icon"
-          isFocused={isFocused}
-          onClick={onClickRightSideIcon}
+    <>
+      <Container height={height}>
+        <Input
+          value={value}
+          borderRadius={borderRadius}
+          onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
+            setIsFocused(true);
+            onFocus?.(event);
+          }}
+          onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
+            setIsFocused(false);
+            onBlur?.(event);
+          }}
+          hasBorder={hasBorder}
+          maxLength={maxLength}
+          {...restTextFieldProps}
         />
-      )}
+        {rightSideIcon && (
+          <RightSideIcon src={rightSideIcon} alt="aside-icon" isFocused={isFocused} onClick={onClickRightSideIcon} />
+        )}
+      </Container>
       {supportsMaxLength && (
         <Caption>
           {value.length}/{maxLength}
         </Caption>
       )}
-    </Container>
+    </>
   );
 };
 

--- a/components/Common/Toast/Toast.styles.ts
+++ b/components/Common/Toast/Toast.styles.ts
@@ -6,15 +6,16 @@ import { ToastType } from '@/shared/type/global';
 export const CustomedToastContainer = styled(ToastContainer)<{
   type: ToastType;
 }>`
-  max-width: 480px;
+  max-width: 48rem;
   text-align: center;
   &.Toastify__toast-container--top-center {
-    margin-top: 94px;
+    margin-top: 9.4rem;
+    z-index: 10001;
   }
   & .Toastify__toast {
     display: inline-flex;
-    min-height: 40px;
-    width: 313px;
+    min-height: 4rem;
+    width: 31.3rem;
     ${theme.fonts.btn2};
   }
   & .Toastify__toast-theme--light {
@@ -30,7 +31,7 @@ export const CustomedToastContainer = styled(ToastContainer)<{
       if (type === 'warning') return theme.colors.black;
       if (type === 'confirm') return theme.colors.white;
     }};
-    padding: 0 12px;
+    padding: 0 1.2rem;
     & > div {
       display: inline-block;
       text-align: center;

--- a/components/Example/ToastExample.tsx
+++ b/components/Example/ToastExample.tsx
@@ -2,14 +2,18 @@ import React from 'react';
 import useToast from '@/hooks/useToast';
 
 const ToastExample = () => {
-  const notify = useToast({
-    type: 'error',
-    message: '이미 존재하는 폴더명이에요.',
-  });
+  const notify = useToast();
+
+  const showToast = () => {
+    notify({
+      type: 'error',
+      message: '이미 존재하는 폴더명이에요.',
+    });
+  };
 
   return (
     <div>
-      <button onClick={notify} style={{ backgroundColor: 'yellow' }}>
+      <button onClick={showToast} style={{ backgroundColor: 'yellow' }}>
         토스트 띄우기
       </button>
     </div>

--- a/components/Home/CollectedFolder/CollectedFolder.styles.ts
+++ b/components/Home/CollectedFolder/CollectedFolder.styles.ts
@@ -30,7 +30,7 @@ export const BoxContainer = styled.figure`
 `;
 
 export const FolderImage = styled.div<{ thumbnail: string }>`
-  max-height: 50%;
+  height: 100%;
   border-radius: 1rem;
   background-image: url(${(props) => props.thumbnail});
   background-color: ${theme.colors.gray3};

--- a/components/Home/FloatingButton/FloatingButton.tsx
+++ b/components/Home/FloatingButton/FloatingButton.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import Image from 'next/image';
+import { transition } from '@/styles/mixins';
+import theme from '@/styles/theme';
+import RightIcon from 'public/svgs/right-small.svg';
+import { CommonButton } from '@/components/Common';
+import { useRouter } from 'next/router';
+
+interface FloatingButtonProps {
+  isScrollOnTop: boolean;
+}
+
+const FloatingButton = ({ isScrollOnTop }: FloatingButtonProps) => {
+  const router = useRouter();
+
+  const goToUndefinedFeelings = () => {
+    router.push('/posts/undefined-feelings');
+  };
+
+  return (
+    <FloatingContainer isHidden={!isScrollOnTop}>
+      <div>
+        <CommonButton color="gray" onClick={goToUndefinedFeelings}>
+          <ButtonText>
+            &apos;모르겠어요&apos;를 선택한 기록들
+            <ButtonIcon>
+              <Image src={RightIcon} alt="" />
+            </ButtonIcon>
+          </ButtonText>
+        </CommonButton>
+      </div>
+    </FloatingContainer>
+  );
+};
+
+const FloatingContainer = styled.div<{ isHidden: boolean }>`
+  ${transition()};
+  position: fixed;
+  left: 0;
+  bottom: 5.6rem;
+  width: 100%;
+  z-index: 1001;
+  ${(props) =>
+    props.isHidden &&
+    css`
+      transform: translate3d(0, 200%, 0);
+    `};
+
+  > div {
+    width: 22.3rem;
+    margin: 0 auto;
+  }
+`;
+
+const ButtonText = styled.span`
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 0 1.9rem 0 2.2rem;
+  ${theme.fonts.btn2};
+`;
+
+const ButtonIcon = styled.i`
+  position: absolute;
+  top: 0;
+  right: 1.9rem;
+`;
+
+export default FloatingButton;

--- a/components/Home/Folder/Folder.styles.ts
+++ b/components/Home/Folder/Folder.styles.ts
@@ -5,7 +5,7 @@ export const FolderContainer = styled.div`
   position: relative;
   width: 100%;
   height: 16.5rem;
-  cursor: pointer;
+  margin-bottom: 4.8rem;
 `;
 
 export const FolderName = styled.p`
@@ -23,6 +23,7 @@ export const BoxContainer = styled.div`
   display: flex;
   width: 100%;
   height: 100%;
+  cursor: pointer;
 
   span {
     border-radius: 1.4rem;

--- a/components/Home/Folder/Folder.tsx
+++ b/components/Home/Folder/Folder.tsx
@@ -18,12 +18,13 @@ export interface FolderProps extends HtmlHTMLAttributes<HTMLDivElement> {
   isEditMode?: boolean;
   supportsMultipleLayout?: boolean;
   folder: Folder;
+  onClick: () => void;
 }
 
 const Folder = ({
   folder: { postCount, folderName, coverImg },
   isEditMode = false,
-  ...rest
+  onClick,
 }: FolderProps): React.ReactElement => {
   const renderDeleteButton = () => {
     return (
@@ -42,22 +43,12 @@ const Folder = ({
   };
 
   return (
-    <FolderContainer {...rest}>
-      <BoxContainer>
+    <FolderContainer>
+      <BoxContainer onClick={onClick}>
         {postCount === 0 ? (
-          <Image
-            src={EmptyImage}
-            alt="기록이 없어요"
-            layout="fill"
-            objectFit="cover"
-          />
+          <Image src={EmptyImage} alt="기록이 없어요" layout="fill" objectFit="cover" />
         ) : (
-          <Image
-            src={coverImg || EmptyImage}
-            alt={folderName}
-            layout="fill"
-            objectFit="cover"
-          />
+          <Image src={coverImg || EmptyImage} alt={folderName} layout="fill" objectFit="cover" />
         )}
         {isEditMode && renderDeleteButton()}
       </BoxContainer>

--- a/hooks/useInput.ts
+++ b/hooks/useInput.ts
@@ -3,18 +3,17 @@ import { useState, ChangeEvent, useCallback } from 'react';
 export default function useInput(initialValue: string) {
   const [inputValue, setInputValue] = useState(initialValue);
 
-  const onChangeInput = useCallback(
-    ({ target }: ChangeEvent<HTMLInputElement>) => {
-      const max = Number(target.getAttribute('maxlength'));
+  const onChangeInput = useCallback(({ target }: ChangeEvent<HTMLInputElement>) => {
+    const max = Number(target.getAttribute('maxlength'));
 
-      if (max && target.value.length > max) {
-        target.value = target.value.slice(0, max);
-      }
+    if (max && target.value.length > max) {
+      target.value = target.value.slice(0, max);
+    }
 
-      setInputValue(target.value);
-    },
-    [],
-  );
+    setInputValue(target.value);
+  }, []);
 
-  return { inputValue, onChangeInput };
+  const resetInputValue = () => setInputValue('');
+
+  return { inputValue, onChangeInput, resetInputValue };
 }

--- a/hooks/useToast.ts
+++ b/hooks/useToast.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { toast } from 'react-toastify';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { ToastType } from '@/shared/type/global';
 import { toastStateAtom } from '@/store/toast/atom';
 
@@ -9,12 +9,15 @@ interface ToastProps {
   message: string;
 }
 
-export default function useToast({ type, message }: ToastProps) {
-  const setToastType = useSetRecoilState(toastStateAtom);
+export default function useToast() {
+  const [type, setToastType] = useRecoilState(toastStateAtom);
 
   useEffect(() => {
     setToastType(type);
   }, [type, setToastType]);
 
-  return () => toast(message);
+  return ({ type, message }: ToastProps) => {
+    setToastType(type);
+    toast(message);
+  };
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,27 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import Image from 'next/image';
-import styled, { css } from 'styled-components';
 import { useSetRecoilState } from 'recoil';
 import { tooltipStateAtom } from '@/store/tooltip/atom';
 import { HOME_TAB_TYPE, CurrentTabType } from '@/shared/constants/home';
-import { transition } from '@/styles/mixins';
-import theme from '@/styles/theme';
 import useDialog from '@/hooks/useDialog';
 import useInput from '@/hooks/useInput';
-import { useFoldersQuery } from '@/hooks/apis';
+import { useFoldersQuery, useIncompletePostsQuery } from '@/hooks/apis';
 import HomeBanner from '@/components/Home/Banner/Banner';
 import HomeTabHeader from '@/components/Home/TabHeader/TabHeader';
 import HomeTabs from '@/components/Home/Tabs/Tabs';
 import HomeHeader from '@/components/Home/Header/Header';
 import FolderList from '@/components/Home/FolderList/FolderList';
-import {
-  CommonButton,
-  CommonDialog,
-  CommonWritingButton,
-} from '@/components/Common';
+import HomeFloatingButton from '@/components/Home/FloatingButton/FloatingButton';
+import { CommonDialog, CommonWritingButton } from '@/components/Common';
 import DialogFolderForm from '@/components/Dialog/DialogFolderForm';
-import RightIcon from 'public/svgs/right-small.svg';
 
 const Home = () => {
   const router = useRouter();
@@ -30,17 +22,12 @@ const Home = () => {
   const { dialogVisible, toggleDialog } = useDialog();
   const { inputValue, onChangeInput } = useInput('');
   const setTooltipState = useSetRecoilState(tooltipStateAtom);
-  const { data } = useFoldersQuery();
-  const [currentTab, setCurrentTab] = useState<CurrentTabType>(
-    HOME_TAB_TYPE.FOLDER,
-  );
+  const { data: folderResponse } = useFoldersQuery();
+  const { data: incompletePosts } = useIncompletePostsQuery();
+  const [currentTab, setCurrentTab] = useState<CurrentTabType>(HOME_TAB_TYPE.FOLDER);
 
   const handleScroll = () => {
     setIsScrollOnTop(window.scrollY === 0);
-  };
-
-  const goToUndefinedFeelings = () => {
-    router.push('/posts/undefined-feelings');
   };
 
   useEffect(() => {
@@ -73,77 +60,24 @@ const Home = () => {
         isEditMode={isEditMode}
         toggleEditMode={() => setIsEditMode(!isEditMode)}
       />
-      <HomeTabs
-        currentTab={currentTab}
-        setCurrentTab={handleCurrentTab}
-        onClick={toggleDialog}
-      />
-      {data && (
+      <HomeTabs currentTab={currentTab} setCurrentTab={handleCurrentTab} onClick={toggleDialog} />
+      {folderResponse?.folders.length && (
         <FolderList
           isEditMode={isEditMode}
-          folderList={data.folders}
+          folderList={folderResponse.folders}
           supportsCollectedFolder={currentTab === HOME_TAB_TYPE.FOLDER}
         />
       )}
       <CommonWritingButton onClick={goToWritePage} />
-      <FloatingContainer isHidden={!isScrollOnTop}>
-        <div>
-          <CommonButton color="gray" onClick={goToUndefinedFeelings}>
-            <ButtonText>
-              &apos;모르겠어요&apos;를 선택한 기록들
-              <ButtonIcon>
-                <Image src={RightIcon} alt="" />
-              </ButtonIcon>
-            </ButtonText>
-          </CommonButton>
-        </div>
-      </FloatingContainer>
+      {incompletePosts?.length && <HomeFloatingButton isScrollOnTop={isScrollOnTop} />}
       {!isScrollOnTop && <CommonWritingButton onClick={goToWritePage} />}
       {dialogVisible && (
-        <CommonDialog
-          type="modal"
-          onClose={toggleDialog}
-          disabledConfirm={inputValue === ''}
-          onConfirm={toggleDialog}
-        >
+        <CommonDialog type="modal" onClose={toggleDialog} disabledConfirm={inputValue === ''} onConfirm={toggleDialog}>
           <DialogFolderForm value={inputValue} onChange={onChangeInput} />
         </CommonDialog>
       )}
     </>
   );
 };
-
-const FloatingContainer = styled.div<{ isHidden: boolean }>`
-  ${transition()};
-  position: fixed;
-  left: 0;
-  bottom: 5.6rem;
-  width: 100%;
-  z-index: 1001;
-  ${(props) =>
-    props.isHidden &&
-    css`
-      transform: translate3d(0, 200%, 0);
-    `};
-
-  > div {
-    width: 22.3rem;
-    margin: 0 auto;
-  }
-`;
-
-const ButtonText = styled.span`
-  position: relative;
-  display: flex;
-  align-items: center;
-  padding: 0 1.9rem 0 2.2rem;
-  ${theme.fonts.btn2};
-`;
-
-const ButtonIcon = styled.i`
-  position: absolute;
-  top: 0;
-  right: 1.9rem;
-`;
 
 export default Home;


### PR DESCRIPTION
## Description

Feature (issue #64)

## Changes

- prettier printWidth 80 -> 120 으로 변경하였습니다. (슬랙에서 구두 논의 완료)
  - prettier printWidth 가 변경되면서 관련 변경사항들이 많이 있습니다..! 사실 해당 api 에는 그렇게 많지 않은데..

- 2차 감정 작성하지 않은 글 목록 API 연동 작업
  - 메인페이지 floating button 노출 분기 처리
  - 폴더 리스트 페이지 이동 시, 빈배열이어서 기록이 없어요. 노출되는 부분 확인

## 스크린샷

기존에 floating button 이 기본적으로 노출이 되고 있었는데 api 연동하면서 데이터가 없어서 아래와 같이 Floating button 이 노출되지 않는 것을 볼 수 있습니다.
<img width="415" alt="스크린샷 2022-05-17 오후 8 02 13" src="https://user-images.githubusercontent.com/29244798/168797295-3073382a-2470-4052-b1ed-be1c237bbdca.png">

페이지 이동 시, 기록이 없어요 노출
<img width="414" alt="스크린샷 2022-05-17 오후 8 02 05" src="https://user-images.githubusercontent.com/29244798/168797282-93e847e5-6c94-458e-9526-46fef4d6bd72.png">

