### PR TITLE
메인페이지 폴더 추가, 수정, 삭제 관련 로직 추가 (#23)

### DIFF
--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
-import { EMOTION_COLOR_TYPE } from '@/shared/constants/emotion';
-import { EmotionColorType } from '@/shared/constants/emotion';
+import { EMOTION_COLOR_TYPE } from '@/shared/constants/category';
+import { EmotionColorType } from '@/shared/constants/category';
 import { CardContainer, ImageContainer } from './Card.styles';
 
 export interface CardProps {

--- a/components/Home/CategoryFolderList/CategoryFolderList.tsx
+++ b/components/Home/CategoryFolderList/CategoryFolderList.tsx
@@ -15,6 +15,7 @@ const CategoryFolderList = ({ list }: CategoryFolderListProps): React.ReactEleme
       {list.map((folder: CategoryFolder) => (
         <HomeFolder
           key={folder.categoryId}
+          folderId={folder.categoryId}
           folderName={folder.description}
           count={folder.count}
           coverImage={folder.image}

--- a/components/Home/Folder/Folder.styles.ts
+++ b/components/Home/Folder/Folder.styles.ts
@@ -6,6 +6,7 @@ export const FolderContainer = styled.div`
   width: 100%;
   height: 16.5rem;
   margin-bottom: 4.8rem;
+  padding-top: 100%;
 `;
 
 export const FolderName = styled.p`
@@ -19,15 +20,17 @@ export const FolderCount = styled.span`
   color: ${theme.colors.gray4};
 `;
 
-export const BoxContainer = styled.div`
+export const BoxContainer = styled.div<{ backgroundImage: string }>`
+  position: absolute;
+  inset: 0;
   display: flex;
   width: 100%;
   height: 100%;
   cursor: pointer;
-
-  span {
-    border-radius: 1.4rem;
-  }
+  background-image: url(${(props) => (props.backgroundImage ? props.backgroundImage : '/images/empty.png')});
+  background-size: contain;
+  background-repeat: no-repeat;
+  border-radius: 1.4rem;
 `;
 
 export const CaptionContainer = styled.figcaption`

--- a/components/Home/Folder/Folder.tsx
+++ b/components/Home/Folder/Folder.tsx
@@ -1,4 +1,4 @@
-import React, { HtmlHTMLAttributes } from 'react';
+import React, { HtmlHTMLAttributes, MouseEvent } from 'react';
 import Image from 'next/image';
 import {
   FolderContainer,
@@ -14,26 +14,56 @@ import TrashIcon from 'public/svgs/trash.svg';
 import EditFolderIcon from 'public/svgs/editfolder.svg';
 
 export interface FolderProps extends HtmlHTMLAttributes<HTMLDivElement> {
+  folderId: number;
   folderName: string;
   count: number;
   coverImage: string;
   isEditMode?: boolean;
   supportsMultipleLayout?: boolean;
   onClick: () => void;
+  onEdit?: (id: number) => void;
+  onDelete?: (id: number) => void;
 }
 
-const Folder = ({ count, folderName, coverImage, isEditMode = false, onClick }: FolderProps): React.ReactElement => {
+const Folder = ({
+  folderId,
+  count,
+  folderName,
+  coverImage,
+  isEditMode = false,
+  onClick,
+  onEdit,
+  onDelete,
+}: FolderProps): React.ReactElement => {
+  const handleDelete = (e: MouseEvent<HTMLSpanElement>) => {
+    if (!onDelete) return;
+    e.stopPropagation();
+
+    onDelete(folderId);
+  };
+
+  const handleEdit = (e: MouseEvent<HTMLSpanElement>) => {
+    if (!onEdit) return;
+
+    e.stopPropagation();
+    onEdit(folderId);
+  };
+
   const renderDeleteButton = () => {
+    if (!onDelete) return;
+
     return (
-      <DeleteButton onClick={() => console.log('delete')}>
-        <Image src={TrashIcon} alt="삭제" width={24} height={24} />
+      <DeleteButton onClick={handleDelete}>
+        <Image src={TrashIcon} alt="삭제" width={32} height={32} />
       </DeleteButton>
     );
   };
 
   const renderEditButton = () => {
+    if (!onEdit) return;
+
     return (
-      <EditButton onClick={() => console.log('edit')}>
+      <EditButton onClick={handleEdit}>
         <Image src={EditFolderIcon} alt="편집" width={24} height={24} />
       </EditButton>
     );
@@ -41,12 +71,7 @@ const Folder = ({ count, folderName, coverImage, isEditMode = false, onClick }: 
 
   return (
     <FolderContainer>
-      <BoxContainer onClick={onClick}>
-        {count === 0 ? (
-          <Image src={EmptyImage} alt="기록이 없어요" layout="fill" objectFit="cover" />
-        ) : (
-          <Image src={coverImage || EmptyImage} alt={folderName} layout="fill" objectFit="cover" />
-        )}
+      <BoxContainer onClick={onClick} backgroundImage={count !== 0 ? coverImage : ''}>
         {isEditMode && renderDeleteButton()}
       </BoxContainer>
       <CaptionContainer>

--- a/components/Home/FolderList/FolderList.tsx
+++ b/components/Home/FolderList/FolderList.tsx
@@ -8,27 +8,38 @@ interface FolderListProps {
   isEditMode: boolean;
   folderList: Folder[];
   supportsCollectedFolder: boolean;
+  onEdit: (id: number) => void;
+  onDelete: (id: number) => void;
 }
 
-const FolderList = ({ isEditMode, folderList, supportsCollectedFolder }: FolderListProps): React.ReactElement => {
+const FolderList = ({
+  isEditMode,
+  folderList,
+  supportsCollectedFolder,
+  onEdit,
+  onDelete,
+}: FolderListProps): React.ReactElement => {
   const router = useRouter();
   const totalCount = folderList.reduce((acc, curr) => acc + curr.postCount, 0);
 
   const goToPosts = () => {
-    router.push('/posts?folderId=0');
+    router.push('/posts');
   };
 
   return (
     <>
       {supportsCollectedFolder && <HomeCollectedFolder count={totalCount} items={folderList} onClick={goToPosts} />}
-      {folderList.map((folder: Folder) => (
+      {folderList.map((folder: Folder, index: number) => (
         <HomeFolder
           key={folder.folderId}
+          folderId={folder.folderId}
           folderName={folder.folderName}
           count={folder.postCount}
           coverImage={folder.coverImg}
-          isEditMode={isEditMode}
+          isEditMode={isEditMode && index !== 0}
           onClick={() => router.push(`/posts?folderId=${folder.folderId}`)}
+          onEdit={onEdit}
+          onDelete={onDelete}
         />
       ))}
     </>

--- a/components/Post/PostList/PostList.tsx
+++ b/components/Post/PostList/PostList.tsx
@@ -5,14 +5,13 @@ import PostItem from '@/components/Post/PostItem/PostItem';
 import { Post } from '@/shared/type/post';
 
 interface PostListProps {
-  folderId: number;
   postList: Post[];
   isEditing: boolean;
   checkedItems: string[];
   setCheckedItems: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-const PostList = ({ folderId, postList, isEditing, checkedItems, setCheckedItems }: PostListProps) => {
+const PostList = ({ postList, isEditing, checkedItems, setCheckedItems }: PostListProps) => {
   const router = useRouter();
 
   const changeCheckedItems = (postId: string) => {
@@ -26,7 +25,7 @@ const PostList = ({ folderId, postList, isEditing, checkedItems, setCheckedItems
 
   const handlePostItemClick = (postId: string) => {
     if (!isEditing) {
-      return router.push(`/posts/${postId}?folderId=${folderId}`);
+      return router.push(`/posts/${postId}`);
     }
 
     changeCheckedItems(postId);

--- a/hooks/apis/folder/useFolderMutation.ts
+++ b/hooks/apis/folder/useFolderMutation.ts
@@ -6,7 +6,7 @@ import { queryClient } from '@/shared/utils/queryClient';
 export const useCreateFolderMutation = () =>
   useMutation((folderName: string) => folderService.createFolder(folderName), {
     onSuccess: () => {
-      queryClient.invalidateQueries(QUERY_KEY.GET_FOLDERS);
+      queryClient.resetQueries(QUERY_KEY.GET_FOLDERS);
     },
     onError: (error) => {
       // TODO: toast로 에러메시지 띄워주기, 문제 : 현재는 toast가 hook이라서 분기문 안에서 호출 불가, toast를 간소화 해야됨
@@ -16,19 +16,15 @@ export const useCreateFolderMutation = () =>
   });
 
 export const useUpdateFolderMutation = () =>
-  useMutation(
-    ({ id, folderName }: { id: number; folderName: string }) =>
-      folderService.updateFolder(id, folderName),
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries(QUERY_KEY.GET_FOLDERS);
-      },
+  useMutation(({ id, folderName }: { id: number; folderName: string }) => folderService.updateFolder(id, folderName), {
+    onSuccess: () => {
+      queryClient.resetQueries(QUERY_KEY.GET_FOLDERS);
     },
-  );
+  });
 
 export const useDeleteFolderMutation = () =>
   useMutation((id: number) => folderService.deleteFolder(id), {
     onSuccess: () => {
-      queryClient.invalidateQueries(QUERY_KEY.GET_FOLDERS);
+      queryClient.resetQueries(QUERY_KEY.GET_FOLDERS);
     },
   });

--- a/hooks/apis/folder/useFoldersQuery.ts
+++ b/hooks/apis/folder/useFoldersQuery.ts
@@ -5,6 +5,6 @@ import { AxiosError } from 'axios';
 import { ServerResponse } from '@/shared/type/common';
 
 const useFoldersQuery = (): UseQueryResult<FolderResponse, AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_FOLDERS, folderService.getFolders, { enabled: false });
+  useQuery(QUERY_KEY.GET_FOLDERS, folderService.getFolders);
 
 export { useFoldersQuery };

--- a/hooks/apis/post/index.ts
+++ b/hooks/apis/post/index.ts
@@ -1,2 +1,4 @@
 export * from './usePostsQuery';
 export * from './usePostMutation';
+export * from './useFirstCategoryQuery';
+export * from './useCategoryListQuery';

--- a/hooks/apis/post/usePostsQuery.ts
+++ b/hooks/apis/post/usePostsQuery.ts
@@ -31,6 +31,9 @@ const usePostByIdQuery = (id: string): UseQueryResult<Post, AxiosError<ServerRes
 const usePostsByCategoryQuery = (): UseQueryResult<CategoryFolder[], AxiosError<ServerResponse>> =>
   useQuery(QUERY_KEY.GET_POSTS_BY_CATEGORIES, postService.getPostsByCategories, { enabled: false });
 
+const usePostsByCategoryQuery = (): UseQueryResult<CategoryFolder[], AxiosError<ServerResponse>> =>
+  useQuery(QUERY_KEY.GET_POSTS_BY_CATEGORIES, postService.getPostsByCategories, { enabled: false });
+
 export {
   usePostsQuery,
   useIncompletePostsQuery,

--- a/hooks/apis/post/usePostsQuery.ts
+++ b/hooks/apis/post/usePostsQuery.ts
@@ -6,8 +6,8 @@ import { AxiosError } from 'axios';
 import { ServerResponse } from '@/shared/type/common';
 import { PAGE_SIZE } from '@/shared/constants/common';
 
-const usePostsQuery = (): UseQueryResult<Post[], AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_POSTS, postService.getPosts);
+const usePostsQuery = (): UseQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
+  useQuery(QUERY_KEY.GET_POSTS, postService.getPosts, { enabled: false });
 
 const useIncompletePostsQuery = (): UseQueryResult<Post[], AxiosError<ServerResponse>> =>
   useQuery(QUERY_KEY.GET_POSTS, postService.getIncompletePosts);
@@ -23,7 +23,9 @@ const usePostsByFolderIdQuery = ({
   page = 0,
   size = PAGE_SIZE,
 }: PostListRequest): UseQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_POSTS_BY_FOLDER_ID, () => postService.getPostsByFolderId({ folderId, page, size }));
+  useQuery(QUERY_KEY.GET_POSTS_BY_FOLDER_ID, () => postService.getPostsByFolderId({ folderId, page, size }), {
+    enabled: false,
+  });
 
 const usePostByIdQuery = (id: string): UseQueryResult<Post, AxiosError<ServerResponse>> =>
   useQuery(QUERY_KEY.GET_POST_BY_ID, () => postService.getPostById(id), { enabled: false });
@@ -31,8 +33,14 @@ const usePostByIdQuery = (id: string): UseQueryResult<Post, AxiosError<ServerRes
 const usePostsByCategoryQuery = (): UseQueryResult<CategoryFolder[], AxiosError<ServerResponse>> =>
   useQuery(QUERY_KEY.GET_POSTS_BY_CATEGORIES, postService.getPostsByCategories, { enabled: false });
 
-const usePostsByCategoryQuery = (): UseQueryResult<CategoryFolder[], AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_POSTS_BY_CATEGORIES, postService.getPostsByCategories, { enabled: false });
+const usePostsByCategoryIdQuery = ({
+  categoryId,
+  page = 0,
+  size = PAGE_SIZE,
+}: PostListRequest): UseQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
+  useQuery(QUERY_KEY.GET_POSTS_BY_CATEGORIES, () => postService.getPostsByCategoryId({ categoryId, page, size }), {
+    enabled: false,
+  });
 
 export {
   usePostsQuery,
@@ -42,4 +50,5 @@ export {
   usePostsByCategoryQuery,
   usePostByIdQuery,
   usePostsByFolderIdQuery,
+  usePostsByCategoryIdQuery,
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useSetRecoilState } from 'recoil';
+import { AxiosError } from 'axios';
 import styled from 'styled-components';
 import { tooltipStateAtom } from '@/store/tooltip/atom';
 import { HOME_TAB_TYPE, CurrentTabType } from '@/shared/constants/home';
@@ -123,10 +124,11 @@ const Home = () => {
           setInputValue('');
           toggleDialog();
         },
-        onError: () => {
+        onError: (error) => {
+          // TODO: type assertion 제거 및 error 관련 type 정의 추가
           notify({
             type: ToastType.ERROR,
-            message: '이미 중복된 폴더명이에요.',
+            message: (error as AxiosError).response?.data.msg,
           });
         },
       },

--- a/service/apis/postService.ts
+++ b/service/apis/postService.ts
@@ -7,10 +7,13 @@ export interface PostSimple extends Omit<Post, 'id'> {
 }
 
 const postService = {
-  getPosts: async (): Promise<Post[]> => {
+  getPosts: async (): Promise<PostListResponse> => {
     const { data } = await fetcher('get', '/api/v1/posts');
 
-    return data;
+    return {
+      posts: data,
+      totalCount: data.length,
+    };
   },
   getPostById: async (id: string): Promise<Post> => {
     const { data } = await fetcher('get', `/api/v1/posts/${id}`);
@@ -54,6 +57,17 @@ const postService = {
     const { data } = await fetcher('get', '/api/v1/posts/categories');
 
     return data;
+  },
+  getPostsByCategoryId: async ({ categoryId, page, size }: PostListRequest): Promise<PostListResponse> => {
+    const { data } = await fetcher('get', `/api/v1/posts/categories/${categoryId}?page=${page}&size=${size}`);
+
+    return {
+      posts: data.posts.map((post: PostSimple) => ({
+        ...post,
+        id: post.postId,
+      })),
+      totalCount: data.totalCount,
+    };
   },
 };
 

--- a/shared/constants/category.ts
+++ b/shared/constants/category.ts
@@ -15,5 +15,4 @@ export const EMOTION_COLOR_TYPE: Dictionary<string> = {
   DONTKNOW: '#a6a6a6',
 } as const;
 
-export type EmotionColorType =
-  typeof EMOTION_COLOR_TYPE[keyof typeof EMOTION_COLOR_TYPE];
+export type EmotionColorType = typeof EMOTION_COLOR_TYPE[keyof typeof EMOTION_COLOR_TYPE];

--- a/shared/type/post.ts
+++ b/shared/type/post.ts
@@ -11,12 +11,13 @@ export interface Post {
 }
 
 export interface PostListRequest extends PageType {
-  folderId: number;
+  folderId?: number;
+  categoryId?: number;
 }
 
 export interface PostListResponse {
   posts: Post[];
-  folderName: string;
+  folderName?: string;
   totalCount: number;
 }
 


### PR DESCRIPTION
## Description

Fixes (issue #23)

폴더 추가, 폴더 수정, 폴더 삭제 관련 로직 추가

## Changes

**메인페이지**
- 폴더 추가, 폴더 수정, 폴더 삭제 mutation 추가 mutate 함수 호출해서 onSuccess, onError 처리 작업

**폴더 리스트 페이지**
- 폴더별 (folderId), 감정별 (categoryId), 모든 글 목록 querystring 을 기준으로 fetching query, data 변경

**공통**
- 감정이라는 단어를 category, emotion 으로 다 다르게 쓰고 있었던 부분을 category 로 통일
- invalidateQueries -> resetQueries 로 변경

## 스크린샷

<img width="499" alt="스크린샷 2022-05-27 오전 12 41 13" src="https://user-images.githubusercontent.com/29244798/170699423-8048369a-e143-4f0a-8d51-98e4bfce50f1.png">

