### PR TITLE
기록 상세 페이지, 수정 페이지 디테일 작업 (#35)

### DIFF
--- a/components/Common/TextField/TextField.styles.ts
+++ b/components/Common/TextField/TextField.styles.ts
@@ -56,7 +56,7 @@ export const Input = styled.input<Pick<TextFieldProps, 'borderRadius' | 'hasBord
 `;
 
 export const RightSideIcon = styled.img<{ isFocused: boolean }>`
-  position: relative;
+  position: absolute;
   right: 3.5rem;
   cursor: pointer;
 

--- a/components/Post/FloatingButton.tsx
+++ b/components/Post/FloatingButton.tsx
@@ -1,0 +1,40 @@
+import React, { ButtonHTMLAttributes } from 'react';
+import styled from 'styled-components';
+import Image from 'next/image';
+import theme from '@/styles/theme';
+import ArrowRightPrimary from '@/public/svgs/arrow-right-primary.svg';
+
+const Button = ({ ...rest }: ButtonHTMLAttributes<HTMLButtonElement>): React.ReactElement => {
+  return (
+    <ButtonContainer {...rest}>
+      <Text>홈으로 돌아가기</Text>
+      <Image src={ArrowRightPrimary} alt="" />
+    </ButtonContainer>
+  );
+};
+
+export default Button;
+
+const ButtonContainer = styled.button`
+  position: fixed;
+  bottom: 8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(100% - 3.6rem);
+  max-width: 44.4rem;
+  height: 4.6rem;
+  padding: 1.5rem 0;
+  background-color: ${theme.colors.gray2};
+  border: 0.1rem solid ${theme.colors.primary};
+  border-radius: 1rem;
+
+  span {
+    ${theme.fonts.btn2};
+    color: ${theme.colors.primary};
+  }
+`;
+
+const Text = styled.span`
+  margin-right: 1rem;
+`;

--- a/components/Post/PostDetail.style.ts
+++ b/components/Post/PostDetail.style.ts
@@ -15,7 +15,7 @@ export const TagContainer = styled.div`
   margin: 2rem -1.8rem 2.4rem;
 
   div {
-    flex: 1 0 auto;
+    flex: 0 1 auto;
   }
 
   div ~ div {

--- a/components/Post/PostItem/PostItem.stories.tsx
+++ b/components/Post/PostItem/PostItem.stories.tsx
@@ -23,5 +23,6 @@ Default.args = {
     disclosure: true,
     createdAt: '날짜',
     tags: ['5조', '작업하는 중..'],
+    my: false,
   },
 };

--- a/pages/posts/[postId].tsx
+++ b/pages/posts/[postId].tsx
@@ -98,10 +98,12 @@ const PostDetail = () => {
         <CommonAppBar.Left>
           <CommonIconButton iconName="left" onClick={() => router.back()} />
         </CommonAppBar.Left>
-        <CommonAppBar.Right>
-          <CommonIconButton iconName="share" />
-          <CommonIconButton iconName="more" onClick={toggleSheet} />
-        </CommonAppBar.Right>
+        {post.my && (
+          <CommonAppBar.Right>
+            <CommonIconButton iconName="share" />
+            <CommonIconButton iconName="more" onClick={toggleSheet} />
+          </CommonAppBar.Right>
+        )}
       </CommonAppBar>
       <PostDetailContainer>
         <TagContainer>

--- a/pages/posts/[postId]/edit.tsx
+++ b/pages/posts/[postId]/edit.tsx
@@ -51,7 +51,7 @@ import FolderPlus from 'public/svgs/folderplus.svg';
 
 const PostDetail = () => {
   const router = useRouter();
-  const { postId } = router.query;
+  const postId = router.query.postId as string;
 
   const { tagList, tagValue, setTagList, onChangeTagValue, onDeleteTag, onKeyPressEnter, onClickRightSideIcon } =
     useTags();
@@ -65,7 +65,7 @@ const PostDetail = () => {
   const { dialogVisible, toggleDialog } = useDialog();
 
   const { data: folderListData } = useFoldersQuery();
-  const { data: post } = usePostByIdQuery(postId as string);
+  const { data: post, refetch: fetchPostById } = usePostByIdQuery(postId);
   const { data: categories } = useCategoryListQuery();
   const { mutate: createFolder } = useCreateFolderMutation();
   const { mutate: updatePost } = useUpdatePostMutation();
@@ -104,7 +104,7 @@ const PostDetail = () => {
     };
 
     updatePost(
-      { id: postId as string, postData: { ...updatedForm, folderId: selectedState.folderId || 0 } },
+      { id: postId, postData: { ...updatedForm, folderId: selectedState.folderId || 0 } },
       {
         onSuccess: () => {
           router.push(`/posts/${postId}`);
@@ -112,6 +112,12 @@ const PostDetail = () => {
       },
     );
   };
+
+  useEffect(() => {
+    if (!router.isReady) return;
+
+    fetchPostById();
+  }, [router.isReady, postId, fetchPostById]);
 
   useEffect(() => {
     if (post) {

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -146,7 +146,7 @@ const PostListPage = () => {
       <CommonAppBar>
         <CommonAppBar.Left>
           <CommonIconButton iconName="left" alt="이전" onClick={() => router.back()} />
-          <HeaderTitle>{postResponse.folderName}</HeaderTitle>
+          <HeaderTitle>{postResponse.folderName || postResponse.categoryName}</HeaderTitle>
         </CommonAppBar.Left>
         <CommonAppBar.Right>
           {isEditing ? (
@@ -156,7 +156,7 @@ const PostListPage = () => {
           )}
         </CommonAppBar.Right>
       </CommonAppBar>
-      {postResponse?.posts?.length ? (
+      {postResponse?.totalCount ? (
         <PostList
           postList={postResponse.posts}
           isEditing={isEditing}

--- a/public/svgs/arrow-right-primary.svg
+++ b/public/svgs/arrow-right-primary.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 4.5L16.5 12L9 19.5" stroke="#FFEC3E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/service/apis/postService.ts
+++ b/service/apis/postService.ts
@@ -10,10 +10,7 @@ const postService = {
   getPosts: async (): Promise<PostListResponse> => {
     const { data } = await fetcher('get', '/api/v1/posts');
 
-    return {
-      posts: data,
-      totalCount: data.length,
-    };
+    return data;
   },
   getPostById: async (id: string): Promise<Post> => {
     const { data } = await fetcher('get', `/api/v1/posts/${id}`);
@@ -51,12 +48,11 @@ const postService = {
     const { data } = await fetcher('get', `/api/v1/folders/posts/${folderId}?page=${page}&size=${size}`);
 
     return {
+      ...data,
       posts: data.posts.map((post: PostSimple) => ({
         ...post,
         id: post.postId,
       })),
-      totalCount: data.totalCount,
-      folderName: data.folderName,
     };
   },
   deletePostById: async (ids: string[]): Promise<PostListResponse> => {
@@ -74,11 +70,11 @@ const postService = {
     const { data } = await fetcher('get', `/api/v1/posts/categories/${categoryId}?page=${page}&size=${size}`);
 
     return {
+      ...data,
       posts: data.posts.map((post: PostSimple) => ({
         ...post,
         id: post.postId,
       })),
-      totalCount: data.totalCount,
     };
   },
 };

--- a/shared/type/post.ts
+++ b/shared/type/post.ts
@@ -8,6 +8,7 @@ export interface Post {
   content: string;
   views: number;
   disclosure: boolean;
+  my: boolean;
   folderId?: number;
   createdAt: string;
 }
@@ -19,6 +20,7 @@ export interface PostListRequest extends PageType {
 
 export interface PostListResponse {
   posts: Post[];
+  categoryName?: string;
   folderName?: string;
   totalCount: number;
 }


### PR DESCRIPTION
## Description

Fixes (issue #35)
수정 페이지, 상세 페이지 디테일 작업

## Changes

- Textfield right side icon position 변경
   - cc. @guymoon 혹시 이후 기문님 작업에 영향이 있을지 확인해주시면 좋을 것 같습니다!
- getPosts service 함수 return value 변경
  - 이전에 { posts, totalCount } 로 반환되지 않아서 프론트에서 처리해줬었는데 API Response 가 변경되어 수정하였습니다.
- 기록 완료 -> 상세페이지에서만 사용되는 Floating button 추가
- Post interface 에 my property 추가, PostListResponse 에 categoryName property 추가

- 수정페이지에서 router.isReady true 일 때 fetchPostById 실행할 수 있게 작업

## 스크린샷

**AS-IS Textfield width 100% 되지 않는 이슈**
<img width="435" alt="스크린샷 2022-05-29 오전 1 09 48" src="https://user-images.githubusercontent.com/29244798/170835159-e143afc1-e499-4de1-98d9-47dbeef466c3.png">

**TO-BE Textfield width 100%**
<img width="430" alt="스크린샷 2022-05-29 오전 1 09 39" src="https://user-images.githubusercontent.com/29244798/170835162-47ab604d-d6a1-4d70-b420-473257d5ac14.png">

**태그 스타일 버그 수정**
<img width="474" alt="스크린샷 2022-05-29 오전 1 12 26" src="https://user-images.githubusercontent.com/29244798/170835170-f8ef72b5-6792-483a-8f04-63d1b27a3465.png">

**작업 완료 페이지에서만 보이는 Floating Button 추가**
<img width="434" alt="스크린샷 2022-05-29 오후 12 11 44" src="https://user-images.githubusercontent.com/29244798/170850347-187de157-95f0-43d0-a37e-b61d23fefb3a.png">

## Checklist

- API 개발되면 수정 페이지에서 기존 folderId 를 가져오는 작업 진행 예정입니다.