### PR TITLE
감정 리스트 bottom sheet 추가

### DIFF
--- a/components/BottomSheetCategoryList/BottomSheetCategoryList.tsx
+++ b/components/BottomSheetCategoryList/BottomSheetCategoryList.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from 'styled-components';
+import { CommonButton } from '../Common';
+
+interface CategoryItem {
+  id: string;
+  label: string;
+}
+
+interface BottomSheetCategoryListProps {
+  items: CategoryItem[];
+  selectedItem: string;
+  onClick: (id: string) => void;
+}
+
+const BottomSheetCategoryList = ({ items, selectedItem, onClick }: BottomSheetCategoryListProps) => {
+  return (
+    <BottomSheetListContainer>
+      {items.map((item: CategoryItem) => (
+        <CommonButton
+          key={item.id}
+          size="medium"
+          color={selectedItem === item.id ? 'primary' : 'gray'}
+          onClick={() => onClick(item.id)}
+        >
+          {item.label}
+        </CommonButton>
+      ))}
+    </BottomSheetListContainer>
+  );
+};
+
+export default BottomSheetCategoryList;
+
+const BottomSheetListContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  padding: 0 3.5rem;
+  grid-gap: 1.3rem;
+`;

--- a/components/Common/AppLayout/AppLayout.styles.ts
+++ b/components/Common/AppLayout/AppLayout.styles.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import theme from '@/styles/theme';
 
 export const Container = styled.main`
-  background-color: ${theme.colors.gray6};
+  background-color: #000;
 `;
 export const ContainerInner = styled.div`
   position: relative;

--- a/components/Common/BottomSheetContainer/BottomSheetContainer.tsx
+++ b/components/Common/BottomSheetContainer/BottomSheetContainer.tsx
@@ -26,20 +26,13 @@ interface BottomSheetProps {
  * - padding은 자연스러운 애니메이션을 위해 콘텐츠들에서 패딩을 확보해줘야함
  */
 
-const BottomSheetContainer = ({
-  children,
-  onClose,
-  BottomSheetHeight,
-  headerTitle,
-}: BottomSheetProps) => {
+const BottomSheetContainer = ({ children, onClose, BottomSheetHeight, headerTitle }: BottomSheetProps) => {
   const { opacityAnimation, heightAnimation, setPrevClose } = useAnimation({
     onClose,
     fullHeight: BottomSheetHeight,
   });
 
-  const bottomSheetRef =
-    typeof window !== 'undefined' &&
-    document.getElementById('root-bottomsheet');
+  const bottomSheetRef = typeof window !== 'undefined' && document.getElementById('root-bottomsheet');
 
   const closeModal = () => {
     setPrevClose(true);
@@ -50,16 +43,12 @@ const BottomSheetContainer = ({
   return createPortal(
     <BottomSheetWrapper>
       <BottomSheetDimmed style={opacityAnimation} onClick={closeModal} />
-      <BottomSheetWrap onClick={closeModal}>
+      <BottomSheetWrap>
         <BottomSheetInner style={heightAnimation}>
           {headerTitle ? (
             <BottomSheetHeader>
               <div>{headerTitle}</div>
-              <CustomImage
-                src={CloseIcon}
-                alt="closeIcon"
-                onClick={closeModal}
-              />
+              <CustomImage src={CloseIcon} alt="closeIcon" onClick={closeModal} />
             </BottomSheetHeader>
           ) : null}
           {children}

--- a/components/Post/PostItem/PostItem.stories.tsx
+++ b/components/Post/PostItem/PostItem.stories.tsx
@@ -16,7 +16,9 @@ Default.args = {
   post: {
     id: '1',
     firstCategory: '모르겠어요',
+    firstCategoryName: 'JOY',
     secondCategory: '기쁨',
+    secondCategoryName: 'JOY',
     content:
       '안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.',
     views: 10,

--- a/components/Post/PostItem/PostItem.tsx
+++ b/components/Post/PostItem/PostItem.tsx
@@ -19,9 +19,8 @@ export interface PostItemProps {
 }
 
 const PostItem = ({
-  post: { id, tags, firstCategory, secondCategory, content, createdAt, views },
+  post: { id, tags, firstCategoryName, secondCategoryName, content, createdAt, views },
   supportsTag = false,
-  canEdit = false,
   isMine = false,
   isEditing = false,
   checked = false,
@@ -48,11 +47,11 @@ const PostItem = ({
       )}
       <ChipContainer>
         {isMine && <HighlightButton>MY</HighlightButton>}
-        <CommonChipButton>{firstCategory}</CommonChipButton>
+        <CommonChipButton>{firstCategoryName}</CommonChipButton>
         <Arrow>
           <Image src={ArrowRightIcon} alt="" width={16} height={16} />
         </Arrow>
-        <CommonChipButton>{secondCategory}</CommonChipButton>
+        <CommonChipButton>{secondCategoryName}</CommonChipButton>
       </ChipContainer>
       <Content>{firstContent}</Content>
       <CaptionContainer>
@@ -63,7 +62,7 @@ const PostItem = ({
   );
 };
 
-const PostItemContainer = styled.div<Pick<PostItemProps, 'isEditing' | 'checked'>>`
+const PostItemContainer = styled.li<Pick<PostItemProps, 'isEditing' | 'checked'>>`
   position: relative;
   display: flex;
   flex-direction: column;

--- a/components/Post/PostList/PostList.tsx
+++ b/components/Post/PostList/PostList.tsx
@@ -36,13 +36,12 @@ const PostList = ({ postList, isEditing, checkedItems, setCheckedItems }: PostLi
   return (
     <PostListContainer>
       {postList.map((post) => (
-        <li key={post.id}>
-          <PostItem
-            {...{ post, isEditing }}
-            checked={isChecked(post.id)}
-            onClick={() => handlePostItemClick(post.id)}
-          />
-        </li>
+        <PostItem
+          {...{ post, isEditing }}
+          key={post.id}
+          checked={isChecked(post.id)}
+          onClick={() => handlePostItemClick(post.id)}
+        />
       ))}
     </PostListContainer>
   );

--- a/hooks/post/usePostEditForm.ts
+++ b/hooks/post/usePostEditForm.ts
@@ -1,0 +1,26 @@
+import { CONTENT_SEPARATOR } from '@/shared/constants/question';
+import { postRequestState } from '@/store/postResponse/atom';
+import { useRecoilState } from 'recoil';
+
+const usePostEditForm = () => {
+  const [selectedState, setSelectedState] = useRecoilState(postRequestState);
+  const hasMultipleContent = selectedState.content.includes(CONTENT_SEPARATOR);
+
+  const changePostForm = (key: string, value: boolean | string) => {
+    setSelectedState({ ...selectedState, [key]: value });
+  };
+
+  const handleCategoryClick = (categoryName: string) => {
+    changePostForm('secondCategory', categoryName);
+  };
+
+  return {
+    selectedState,
+    setSelectedState,
+    hasMultipleContent,
+    changePostForm,
+    handleCategoryClick,
+  };
+};
+
+export default usePostEditForm;

--- a/pages/posts/[postId]/edit.tsx
+++ b/pages/posts/[postId]/edit.tsx
@@ -110,6 +110,7 @@ const PostDetail = () => {
   useEffect(() => {
     if (!router.isReady) return;
 
+    // TODO: DONTKNOW 상수로 분리 or API response 에 있는 것으로 변경해야 합니다.
     if (secondCategory === 'DONTKNOW') {
       toggleSheet();
     }

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -224,10 +224,11 @@ const GuideMessage = styled.p`
 
 const BottomController = styled.div`
   position: fixed;
-  left: 0;
   bottom: 0;
   width: 100%;
+  max-width: 48rem;
   height: 9rem;
+  margin-left: -1.8rem;
   display: flex;
   justify-content: space-between;
   background-color: ${theme.colors.black};

--- a/shared/type/post.ts
+++ b/shared/type/post.ts
@@ -5,6 +5,8 @@ export interface Post {
   tags: string[];
   firstCategory: string;
   secondCategory: string;
+  firstCategoryName: string;
+  secondCategoryName: string;
   content: string;
   views: number;
   disclosure: boolean;


### PR DESCRIPTION
## Description

Fixes (issue #35)

## Changes

- BottomSheetCategoryList 컴포넌트 추가
   - 감정 리스트 바텀시트로 사용하기 위해 추가하였습니다.
- BottomSheetWrap 에 있는 이벤트 핸들러 제거

- usePostEditForm custom hooks 추가
- firstCategoryName, secondCategoryName property 추가 (API 에서 추가해준 필드 추가하였습니다!)

**💅 style**
- AppLayout container background color 변경 (gray6 -> #000)

## 스크린샷

**모르겠어요 선택한 글 수정 시, 하단 바텀시트 노출**
<img width="439" alt="스크린샷 2022-05-29 오후 6 35 32" src="https://user-images.githubusercontent.com/29244798/170901471-01682ca2-c24e-4ae3-8eda-7c0e100bbe9e.png">

**480px 초과하는 width background #000 으로 변경**
<img width="1327" alt="스크린샷 2022-05-30 오전 10 28 33" src="https://user-images.githubusercontent.com/29244798/170901478-cf0bdc91-41ce-4ca8-9b94-fa6cfb0f05b1.png">

