### PR TITLE
useIsMounted hooks 로직 변경 

### DIFF
--- a/hooks/useIsMounted.ts
+++ b/hooks/useIsMounted.ts
@@ -1,15 +1,20 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export const useIsMounted = () => {
-  const isMounted = useRef(false);
+  const elementRef = useRef(false);
+  const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
-    isMounted.current = true;
+    elementRef.current = true;
 
     return () => {
-      isMounted.current = false;
+      elementRef.current = false;
     };
   }, []);
 
-  return useCallback(() => isMounted.current, []);
+  useEffect(() => {
+    setIsMounted(elementRef.current);
+  }, [isMounted]);
+
+  return isMounted;
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -180,7 +180,7 @@ const Home = () => {
   return (
     <>
       <HomeHeader />
-      {isMounted() && <HomeBanner title={randomTitleCases[randomTitleIndex]} background={randomImageSource} />}
+      {isMounted && <HomeBanner title={randomTitleCases[randomTitleIndex]} background={randomImageSource} />}
       <HomeTabHeader
         currentTab={currentTab}
         isEditMode={isEditMode}


### PR DESCRIPTION
## Description

Fixes (issue #25 )

## Changes

[레퍼런스](https://usehooks-ts.com/react-hook/use-is-mounted)를 참고하여 useIsMounted hooks 를 만들었는데,
client side 에서 isMounted() 가 false 로 되어 메인 배너가 노출되지 않는 이슈가 있었습니다.

그래서 useIsMounted hooks 를 수정하였고, isMounted 가 바뀔 때마다 setIsMounted 에 elementRef.current 값을 바인딩하는 방향으로 버그를 해결하였습니다.

