### PR TITLE
kakao redirect url location -> window.location.origin 으로 변경

### DIFF
--- a/pages/oauth/index.tsx
+++ b/pages/oauth/index.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
-import { ROUTES } from '../../shared/constants/routes';
+import { KAKAO_CLIENT_ID, KAKAO_REDIRECT_URL } from '@/shared/constants/auth';
 
 const Login = () => {
   const router = useRouter();
 
   const goKakaoCallback = async () => {
-    router.push(ROUTES.KAKAO_AUTH);
+    const kakaoRedirectURL = `${window.location.origin}${KAKAO_REDIRECT_URL}`;
+    router.push(
+      `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${kakaoRedirectURL}&response_type=code`,
+    );
   };
 
   return (

--- a/shared/constants/auth.ts
+++ b/shared/constants/auth.ts
@@ -1,2 +1,2 @@
 export const KAKAO_CLIENT_ID = '6632ea97bbe44cd0282ac3afff861f67';
-export const KAKAO_REDIRECT_URL = 'http://localhost:3000/oauth/callback/kakao';
+export const KAKAO_REDIRECT_URL = '/oauth/callback/kakao';

--- a/shared/constants/routes.ts
+++ b/shared/constants/routes.ts
@@ -1,8 +1,6 @@
-import { KAKAO_CLIENT_ID, KAKAO_REDIRECT_URL } from './auth';
-
+// TODO: 이후 type safe router 를 만들기 위해 다른 route도 추가가 되어야합니다.
 export const ROUTES = {
   HOME: '/',
   AUTH_CALLBACK_KAKAO: '/oauth/callback/kakao',
   LOGIN: '/oauth',
-  KAKAO_AUTH: `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URL}&response_type=code`,
 } as const;


### PR DESCRIPTION
## Description

Vercel 로 배포되어있는 https://11th-5team-fe.vercel.app/ 에서 kakao login 시,
kakao redirect url 이 기본으로 http://localhost:3000 으로 되어있어서 이슈가 있습니다.

## Changes

기존 KAKAO_REDIRECT_URL 에서 protocol + domain 을 제거하고, goKakaoCallback 함수 내에서 window.location.origin + kakao redirect url 을 조합하여 redirect url로 만들었습니다.
