### PR TITLE
기록 리스트 페이지 무한스크롤

### DIFF
--- a/hooks/apis/folder/useFoldersQuery.ts
+++ b/hooks/apis/folder/useFoldersQuery.ts
@@ -9,6 +9,6 @@ const useFoldersQuery = (): UseQueryResult<FolderResponse, AxiosError<ServerResp
   useQuery(QUERY_KEY.GET_FOLDERS, folderService.getFolders);
 
 const useFolderByPostIdQuery = (postId: string): UseQueryResult<Folder, AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_FOLDER_BY_POST_ID, () => folderService.getFolderByPostId(postId));
+  useQuery(QUERY_KEY.GET_FOLDER_BY_POST_ID, () => folderService.getFolderByPostId(postId), { enabled: !!postId });
 
 export { useFoldersQuery, useFolderByPostIdQuery };

--- a/hooks/apis/folder/useFoldersQuery.ts
+++ b/hooks/apis/folder/useFoldersQuery.ts
@@ -9,6 +9,6 @@ const useFoldersQuery = (): UseQueryResult<FolderResponse, AxiosError<ServerResp
   useQuery(QUERY_KEY.GET_FOLDERS, folderService.getFolders);
 
 const useFolderByPostIdQuery = (postId: string): UseQueryResult<Folder, AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_FOLDER_BY_POST_ID, () => folderService.getFolderByPostId(postId), { enabled: false });
+  useQuery(QUERY_KEY.GET_FOLDER_BY_POST_ID, () => folderService.getFolderByPostId(postId));
 
 export { useFoldersQuery, useFolderByPostIdQuery };

--- a/hooks/apis/post/usePostsQuery.ts
+++ b/hooks/apis/post/usePostsQuery.ts
@@ -3,23 +3,15 @@ import postService from '@/service/apis/postService';
 import { QUERY_KEY } from '@/shared/constants/queryKey';
 import { Post, PostListRequest, PostListResponse, CategoryFolder } from '@/shared/type/post';
 import { AxiosError } from 'axios';
-import { PaginationParam, ServerResponse } from '@/shared/type/common';
-import { PAGE_SIZE } from '@/shared/constants/common';
+import { ServerResponse } from '@/shared/type/common';
 
 const usePostsQuery = (): UseInfiniteQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
-  useInfiniteQuery(
-    QUERY_KEY.GET_POSTS,
-    ({ pageParam = 0 }) => postService.getPosts({ page: pageParam, size: PAGE_SIZE }),
-    {
-      getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextPage : undefined),
-    },
-  );
+  useInfiniteQuery(QUERY_KEY.GET_POSTS, ({ pageParam = 0 }) => postService.getPosts(pageParam), {
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextPage : undefined),
+  });
 
-const useIncompletedPostsQuery = ({
-  page,
-  size = PAGE_SIZE,
-}: PaginationParam): UseQueryResult<Post[], AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_POSTS, () => postService.getIncompletedPosts({ page, size }));
+const useIncompletedPostsQuery = (page = 0): UseQueryResult<Post[], AxiosError<ServerResponse>> =>
+  useQuery(QUERY_KEY.GET_POSTS, () => postService.getIncompletedPosts(page));
 
 const usePostQuery = (id: string): UseQueryResult<Post, AxiosError<ServerResponse>> =>
   useQuery(QUERY_KEY.GET_POSTS, () => postService.getPostById(id));
@@ -29,7 +21,7 @@ const usePostsByFolderIdQuery = ({
 }: PostListRequest): UseInfiniteQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
   useInfiniteQuery(
     QUERY_KEY.GET_POSTS_BY_FOLDER_ID,
-    ({ pageParam = 0 }) => postService.getPostsByFolderId({ folderId, page: pageParam, size: PAGE_SIZE }),
+    ({ pageParam = 0 }) => postService.getPostsByFolderId({ folderId, page: pageParam }),
     {
       getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextPage : undefined),
       enabled: !!folderId,
@@ -47,7 +39,7 @@ const usePostsByCategoryIdQuery = ({
 }: PostListRequest): UseInfiniteQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
   useInfiniteQuery(
     QUERY_KEY.GET_POSTS_BY_CATEGORIES,
-    ({ pageParam = 0 }) => postService.getPostsByCategoryId({ categoryId, page: pageParam, size: PAGE_SIZE }),
+    ({ pageParam = 0 }) => postService.getPostsByCategoryId({ categoryId, page: pageParam }),
     {
       getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextPage : undefined),
       enabled: !!categoryId,

--- a/hooks/apis/post/usePostsQuery.ts
+++ b/hooks/apis/post/usePostsQuery.ts
@@ -1,52 +1,63 @@
-import { useQuery, UseQueryResult } from 'react-query';
+import { useQuery, UseQueryResult, useInfiniteQuery, UseInfiniteQueryResult } from 'react-query';
 import postService from '@/service/apis/postService';
 import { QUERY_KEY } from '@/shared/constants/queryKey';
 import { Post, PostListRequest, PostListResponse, CategoryFolder } from '@/shared/type/post';
 import { AxiosError } from 'axios';
-import { ServerResponse } from '@/shared/type/common';
+import { PaginationParam, ServerResponse } from '@/shared/type/common';
 import { PAGE_SIZE } from '@/shared/constants/common';
 
-const usePostsQuery = (): UseQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_POSTS, postService.getPosts, { enabled: false });
+const usePostsQuery = (): UseInfiniteQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
+  useInfiniteQuery(
+    QUERY_KEY.GET_POSTS,
+    ({ pageParam = 0 }) => postService.getPosts({ page: pageParam, size: PAGE_SIZE }),
+    {
+      getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextPage : undefined),
+    },
+  );
 
-const useIncompletedPostsQuery = (): UseQueryResult<Post[], AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_POSTS, postService.getIncompletedPosts);
+const useIncompletedPostsQuery = ({
+  page,
+  size = PAGE_SIZE,
+}: PaginationParam): UseQueryResult<Post[], AxiosError<ServerResponse>> =>
+  useQuery(QUERY_KEY.GET_POSTS, () => postService.getIncompletedPosts({ page, size }));
 
 const usePostQuery = (id: string): UseQueryResult<Post, AxiosError<ServerResponse>> =>
   useQuery(QUERY_KEY.GET_POSTS, () => postService.getPostById(id));
 
-const useAllPostsQuery = (): UseQueryResult<Post[], AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_POSTS, postService.getAllPosts);
-
 const usePostsByFolderIdQuery = ({
   folderId,
-  page = 0,
-  size = PAGE_SIZE,
-}: PostListRequest): UseQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_POSTS_BY_FOLDER_ID, () => postService.getPostsByFolderId({ folderId, page, size }), {
-    enabled: false,
-  });
+}: PostListRequest): UseInfiniteQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
+  useInfiniteQuery(
+    QUERY_KEY.GET_POSTS_BY_FOLDER_ID,
+    ({ pageParam = 0 }) => postService.getPostsByFolderId({ folderId, page: pageParam, size: PAGE_SIZE }),
+    {
+      getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextPage : undefined),
+      enabled: !!folderId,
+    },
+  );
 
 const usePostByIdQuery = (id: string): UseQueryResult<Post, AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_POST_BY_ID, () => postService.getPostById(id), { enabled: false });
+  useQuery(QUERY_KEY.GET_POST_BY_ID, () => postService.getPostById(id), { enabled: !!id });
 
 const usePostsByCategoryQuery = (): UseQueryResult<CategoryFolder[], AxiosError<ServerResponse>> =>
   useQuery(QUERY_KEY.GET_POSTS_BY_CATEGORIES, postService.getPostsByCategories, { enabled: false });
 
 const usePostsByCategoryIdQuery = ({
   categoryId,
-  page = 0,
-  size = PAGE_SIZE,
-}: PostListRequest): UseQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_POSTS_BY_CATEGORIES, () => postService.getPostsByCategoryId({ categoryId, page, size }), {
-    enabled: false,
-  });
+}: PostListRequest): UseInfiniteQueryResult<PostListResponse, AxiosError<ServerResponse>> =>
+  useInfiniteQuery(
+    QUERY_KEY.GET_POSTS_BY_CATEGORIES,
+    ({ pageParam = 0 }) => postService.getPostsByCategoryId({ categoryId, page: pageParam, size: PAGE_SIZE }),
+    {
+      getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextPage : undefined),
+      enabled: !!categoryId,
+    },
+  );
 
 export {
   usePostsQuery,
   useIncompletedPostsQuery,
   usePostQuery,
-  useAllPostsQuery,
   usePostsByCategoryQuery,
   usePostByIdQuery,
   usePostsByFolderIdQuery,

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+interface IntersectionObserverProps extends IntersectionObserverInit {
+  onIntersect: IntersectionObserverCallback;
+}
+
+const useIntersectionObserver = ({
+  onIntersect,
+  threshold = 0,
+  root = null,
+  rootMargin = '0%',
+}: IntersectionObserverProps) => {
+  const [entry, setEntry] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!entry) return;
+
+    const hasIOSupport = !!window.IntersectionObserver;
+
+    if (!hasIOSupport || !entry) return;
+
+    const observerParams = { threshold, root, rootMargin };
+    const observer = new IntersectionObserver(onIntersect, observerParams);
+
+    observer.observe(entry);
+
+    return () => observer.unobserve(entry);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onIntersect, JSON.stringify(threshold), root, rootMargin]);
+
+  return { setEntry };
+};
+
+export default useIntersectionObserver;

--- a/pages/posts/[postId].tsx
+++ b/pages/posts/[postId].tsx
@@ -72,7 +72,7 @@ const PostDetail = () => {
     if (postId) {
       fetchPost();
     }
-  }, [router.query, postId, fetchPost]);
+  }, [fetchPost, postId]);
 
   // TODO: 오류 페이지 이후 작업 요청해서 바꾸기..
   if (!post || !postId) return <div>404</div>;
@@ -81,7 +81,7 @@ const PostDetail = () => {
   const contents = post.content.split(CONTENT_SEPARATOR);
 
   const onDelete = () => {
-    deletePostMutation.mutate([postId as string], {
+    deletePostMutation.mutate([postId], {
       onSuccess: () => {
         router.push(`/posts?folderId=${folderId}`);
         notify({

--- a/service/apis/postService.ts
+++ b/service/apis/postService.ts
@@ -1,3 +1,4 @@
+import { PAGE_SIZE } from '@/shared/constants/common';
 import { Post, PostListRequest, PostListResponse, CategoryFolder } from '@/shared/type/post';
 import { PostRequestType } from '@/shared/type/post';
 import fetcher from '@/shared/utils/fetcher';
@@ -7,23 +8,22 @@ export interface PostSimple extends Omit<Post, 'id'> {
 }
 
 const postService = {
-  getPosts: async (): Promise<PostListResponse> => {
-    const { data } = await fetcher('get', '/api/v1/posts');
+  getPosts: async (page = 0): Promise<PostListResponse> => {
+    const { data } = await fetcher('get', `/api/v1/posts?page=${page}&size=${PAGE_SIZE}`);
 
-    return data;
+    return {
+      ...data,
+      nextPage: page + 1,
+      hasNext: data.totalCount - (page + 1) * PAGE_SIZE > 0,
+    };
   },
   getPostById: async (id: string): Promise<Post> => {
     const { data } = await fetcher('get', `/api/v1/posts/${id}`);
 
     return data;
   },
-  getIncompletedPosts: async (): Promise<Post[]> => {
-    const { data } = await fetcher('get', '/api/v1/posts/temp');
-
-    return data;
-  },
-  getAllPosts: async (): Promise<Post[]> => {
-    const { data } = await fetcher('get', '/api/v1/posts/all');
+  getIncompletedPosts: async (page = 0): Promise<Post[]> => {
+    const { data } = await fetcher('get', `/api/v1/posts/temp?page=${page}&size=${PAGE_SIZE}`);
 
     return data;
   },
@@ -44,11 +44,14 @@ const postService = {
 
     return data;
   },
-  getPostsByFolderId: async ({ folderId, page, size }: PostListRequest): Promise<PostListResponse> => {
-    const { data } = await fetcher('get', `/api/v1/folders/${folderId}/posts?page=${page}&size=${size}`);
+  getPostsByFolderId: async ({ folderId, page = 0 }: PostListRequest): Promise<PostListResponse> => {
+    const { data } = await fetcher('get', `/api/v1/folders/${folderId}/posts?page=${page}&size=${PAGE_SIZE}`);
 
+    // TODO: 중복로직 리팩터링 예정입니다. 또는 API Response 예정..
     return {
       ...data,
+      nextPage: page + 1,
+      hasNext: data.totalCount - (page + 1) * PAGE_SIZE > 0,
       posts: data.posts.map((post: PostSimple) => ({
         ...post,
         id: post.postId,
@@ -66,11 +69,13 @@ const postService = {
 
     return data;
   },
-  getPostsByCategoryId: async ({ categoryId, page, size }: PostListRequest): Promise<PostListResponse> => {
-    const { data } = await fetcher('get', `/api/v1/posts/categories/${categoryId}?page=${page}&size=${size}`);
+  getPostsByCategoryId: async ({ categoryId, page = 0 }: PostListRequest): Promise<PostListResponse> => {
+    const { data } = await fetcher('get', `/api/v1/posts/categories/${categoryId}?page=${page}&size=${PAGE_SIZE}`);
 
     return {
       ...data,
+      nextPage: page + 1,
+      hasNext: data.totalCount - (page + 1) * PAGE_SIZE > 0,
       posts: data.posts.map((post: PostSimple) => ({
         ...post,
         id: post.postId,

--- a/shared/type/common.ts
+++ b/shared/type/common.ts
@@ -9,9 +9,14 @@ export interface ServerResponse {
   success: boolean;
 }
 
-export interface PageType {
+export interface PaginationParam {
   page?: number;
   size?: number;
+}
+
+export interface Pagination {
+  nextPage?: number;
+  hasNext?: boolean;
 }
 
 export const ToastType = {

--- a/shared/type/post.ts
+++ b/shared/type/post.ts
@@ -1,4 +1,4 @@
-import { PageType } from './common';
+import { Pagination, PaginationParam } from './common';
 
 export interface Post {
   id: string;
@@ -15,12 +15,12 @@ export interface Post {
   createdAt: string;
 }
 
-export interface PostListRequest extends PageType {
+export interface PostListRequest extends PaginationParam {
   folderId?: number;
   categoryId?: number;
 }
 
-export interface PostListResponse {
+export interface PostListResponse extends Pagination {
   posts: Post[];
   categoryName?: string;
   folderName?: string;


### PR DESCRIPTION
## Description

Fixes (issue #62, #63)

## Changes

- useIntersectionObserver hooks 추가

**사용방법**

```jsx
  const { setEntry } = useIntersectionObserver({
    onIntersect: ([{ isIntersecting }]) => {
      if (isIntersecting && hasNextPage) {
        fetchNextPage();
      }
    },
  }); 

   return (
     <>
        <div ref={setEntry}>Loading</div>
     </>
   )
```
- post 리스트 페이지 내 무한 스크롤 적용
   - post list api 모두 useInfiniteQuery 로 변경
   - return value 에 hasNext totalCount, page, size 로 계산하여 추가
   - size 는 고정값 (PAGE_SIZE) 으로 사용하고 있다보니 parameter 에서 모두 제거하고 page 만 받게 변경하였습니다.

## 스크린샷

https://user-images.githubusercontent.com/29244798/171973016-1219c805-04f9-4852-ba75-042f1561502b.mov


## TODO

- pre-rendering 시 router.query object 가 비어있어서 useQuery 실행 시 enabled 옵션을 사용하였습니다. (이전 쿼리에 의존할 때 사용하여야 하는데 잘못 사용하고 있는 부분이라서 이후 리팩토링 할 예정입니다.)
- React Query 사용하는 부분 모두 리팩토링 예정입니다. (useQueryClient hooks 를 사용해야 하는 부분이 있다면 변경 예정입니다.)
- post list 페이지에서 때에 따라 3개의 API 중 적절한 API 를 호출하고 있는데 이 부분 리팩토링 하고자 합니다.

