### PR TITLE
공유하기, 상세 페이지에서만 사용되는 버튼 컴포넌트 재사용 할 수 있게 추가 (#132)

### DIFF
--- a/components/Common/ButtonWithIcon/ButtonWithIcon.stories.tsx
+++ b/components/Common/ButtonWithIcon/ButtonWithIcon.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import ButtonWithIcon from './ButtonWithIcon';
+
+export default {
+  component: ButtonWithIcon,
+  title: 'ButtonWithIcon',
+} as Meta;
+
+const Template: Story = (args) => <ButtonWithIcon {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  onClick: action('click the button'),
+  children: 'Button Example',
+};

--- a/components/Common/ButtonWithIcon/ButtonWithIcon.tsx
+++ b/components/Common/ButtonWithIcon/ButtonWithIcon.tsx
@@ -1,0 +1,37 @@
+import React, { ButtonHTMLAttributes } from 'react';
+import styled from 'styled-components';
+import Image from 'next/image';
+import theme from '@/styles/theme';
+import ArrowRightPrimary from 'public/svgs/arrow-right-primary.svg';
+
+const ButtonWithIcon = ({ children, ...rest }: ButtonHTMLAttributes<HTMLButtonElement>): React.ReactElement => {
+  return (
+    <ButtonContainer {...rest}>
+      <Text>{children}</Text>
+      <Image src={ArrowRightPrimary} alt="" width={24} height={24} />
+    </ButtonContainer>
+  );
+};
+
+export default ButtonWithIcon;
+
+const ButtonContainer = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 4.6rem;
+  padding: 1.6rem 0;
+  background-color: ${theme.colors.gray2};
+  border: 0.1rem solid ${theme.colors.primary};
+  border-radius: 1rem;
+
+  span {
+    ${theme.fonts.btn2};
+    color: ${theme.colors.primary};
+  }
+`;
+
+const Text = styled.span`
+  margin-right: 1rem;
+`;

--- a/components/Common/index.tsx
+++ b/components/Common/index.tsx
@@ -2,6 +2,7 @@ export { default as CommonAlert } from './Alert/Alert';
 export { default as CommonAppLayout } from './AppLayout/AppLayout';
 export { default as CommonBottomSheetContainer } from './BottomSheetContainer/BottomSheetContainer';
 export { default as CommonButton } from './Button/Button';
+export { default as CommonButtonWithIcon } from './ButtonWithIcon/ButtonWithIcon';
 export { default as CommonDialog } from './Dialog/Dialog';
 export { default as CommonChipButton } from './ChipButton/ChipButton';
 export { default as CommonToast } from './Toast/Toast';

--- a/components/Post/FloatingButton.tsx
+++ b/components/Post/FloatingButton.tsx
@@ -1,40 +1,26 @@
-import React, { ButtonHTMLAttributes } from 'react';
+import React from 'react';
+import { useRouter } from 'next/router';
 import styled from 'styled-components';
-import Image from 'next/image';
-import theme from '@/styles/theme';
-import ArrowRightPrimary from '@/public/svgs/arrow-right-primary.svg';
+import { CommonButtonWithIcon } from '../Common';
 
-const Button = ({ ...rest }: ButtonHTMLAttributes<HTMLButtonElement>): React.ReactElement => {
+const PostFloatingButton = (): React.ReactElement => {
+  const router = useRouter();
   return (
-    <ButtonContainer {...rest}>
-      <Text>홈으로 돌아가기</Text>
-      <Image src={ArrowRightPrimary} alt="" />
+    <ButtonContainer>
+      <CommonButtonWithIcon onClick={() => router.push('/')}>홈으로 돌아가기</CommonButtonWithIcon>
     </ButtonContainer>
   );
 };
 
-export default Button;
+export default PostFloatingButton;
 
-const ButtonContainer = styled.button`
+const ButtonContainer = styled.div`
   position: fixed;
-  bottom: 8rem;
+  bottom: 0;
   display: flex;
   align-items: center;
-  justify-content: center;
   width: calc(100% - 3.6rem);
+  height: 22.4rem;
   max-width: 44.4rem;
-  height: 4.6rem;
-  padding: 1.5rem 0;
-  background-color: ${theme.colors.gray2};
-  border: 0.1rem solid ${theme.colors.primary};
-  border-radius: 1rem;
-
-  span {
-    ${theme.fonts.btn2};
-    color: ${theme.colors.primary};
-  }
-`;
-
-const Text = styled.span`
-  margin-right: 1rem;
+  background: linear-gradient(180deg, rgba(18, 18, 18, 0) 0%, #121212 100%);
 `;


### PR DESCRIPTION
## Description

Fixes (issue #132)

## Changes

- ButtonWithIcon 컴포넌트 추가
  - 현재는 icon 을 고정으로 두었습니다. 이후에 확장이 필요하면 icon 을 props 로 받을 수 있게 변경하겠습니다!

- post 상세 페이지 내 ButtonWithIcon 적용 

## 스크린샷

**아이콘 + 버튼**
<img width="678" alt="스크린샷 2022-06-04 오전 11 26 21" src="https://user-images.githubusercontent.com/29244798/171975155-fad66ba9-9dfd-4eee-b174-2f7ad618e7ba.png">

**상세 페이지 적용 (with gradation)**
<img width="454" alt="스크린샷 2022-06-04 오전 11 36 53" src="https://user-images.githubusercontent.com/29244798/171975216-dd91e164-57d1-4851-bb81-5a5694c7b620.png">

