### PR TITLE
CollectedFolder 스타일 수정, Random Banner 컴포넌트 hooks 수정 (#25)

### DIFF
--- a/components/Home/CollectedFolder/CollectedFolder.styles.ts
+++ b/components/Home/CollectedFolder/CollectedFolder.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import theme from '@/styles/theme';
 
 export const CollectedFolderContainer = styled.figure`
@@ -30,8 +30,13 @@ export const BoxContainer = styled.figure`
 `;
 
 export const FolderImage = styled.div<{ thumbnail: string }>`
-  height: 8rem;
   border-radius: 1rem;
-  background-image: url(${(props) => props.thumbnail});
+  padding-top: 100%;
+  background-size: cover;
   background-color: ${theme.colors.gray3};
+  ${(props) =>
+    props.thumbnail &&
+    css`
+      background-image: url(${props.thumbnail});
+    `};
 `;

--- a/components/Home/CollectedFolder/CollectedFolder.tsx
+++ b/components/Home/CollectedFolder/CollectedFolder.tsx
@@ -7,26 +7,20 @@ import {
   BoxContainer,
   FolderImage,
 } from './CollectedFolder.styles';
-import { Folder } from '@/shared/type/folder';
-import { MAX_THUMBNAIL_SIZE } from '@/shared/constants/home';
 
-// TODO: 이후 mocking 추가하면서 알맞는 폴더에 위치할 예정
-export interface CollectedFolderProps
-  extends HtmlHTMLAttributes<HTMLDivElement> {
+export interface CollectedFolderProps extends HtmlHTMLAttributes<HTMLDivElement> {
   count: number;
-  items: Folder[];
+  items: string[];
 }
 
-const CollectedFolder = ({
-  count,
-  items,
-  ...rest
-}: CollectedFolderProps): React.ReactElement => {
+const CollectedFolder = ({ count, items, ...rest }: CollectedFolderProps): React.ReactElement => {
+  const validThumbnails = items.map((item, index) => (index < count ? item : ''));
+
   return (
     <CollectedFolderContainer {...rest}>
       <BoxContainer>
-        {items.slice(0, MAX_THUMBNAIL_SIZE).map((item) => (
-          <FolderImage key={item.folderId} thumbnail={item.coverImg} />
+        {validThumbnails.map((item, index) => (
+          <FolderImage key={index} thumbnail={item} />
         ))}
       </BoxContainer>
       <Caption>

--- a/components/Home/FolderList/FolderList.tsx
+++ b/components/Home/FolderList/FolderList.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 interface FolderListProps {
   isEditMode: boolean;
   folderList: Folder[];
+  thumbnailList?: string[];
   supportsCollectedFolder: boolean;
   onEdit: (id: number) => void;
   onDelete: (id: number) => void;
@@ -15,6 +16,7 @@ interface FolderListProps {
 const FolderList = ({
   isEditMode,
   folderList,
+  thumbnailList,
   supportsCollectedFolder,
   onEdit,
   onDelete,
@@ -28,7 +30,9 @@ const FolderList = ({
 
   return (
     <>
-      {supportsCollectedFolder && <HomeCollectedFolder count={totalCount} items={folderList} onClick={goToPosts} />}
+      {supportsCollectedFolder && (
+        <HomeCollectedFolder count={totalCount} items={thumbnailList || []} onClick={goToPosts} />
+      )}
       {folderList.map((folder) => (
         <HomeFolder
           key={folder.folderId}

--- a/components/Post/PostDetail.style.ts
+++ b/components/Post/PostDetail.style.ts
@@ -15,7 +15,7 @@ export const TagContainer = styled.div`
   margin: 2rem -1.8rem 2.4rem;
 
   div {
-    flex: 0 1 auto;
+    flex: 0 0 auto;
   }
 
   div ~ div {

--- a/components/Post/PostItem/PostItem.tsx
+++ b/components/Post/PostItem/PostItem.tsx
@@ -86,6 +86,9 @@ const PostItemContainer = styled.li<Pick<PostItemProps, 'isEditing' | 'checked'>
 
 const TagList = styled.div`
   display: flex;
+  flex-wrap: wrap;
+  overflow-y: hidden;
+  height: 3rem;
   margin-bottom: 2.4rem;
 
   div ~ div {

--- a/hooks/useRandomBanner.ts
+++ b/hooks/useRandomBanner.ts
@@ -1,10 +1,21 @@
 import { TOTAL_BANNER_BACKGROUND_SIZE } from '@/shared/constants/home';
+import { ReactNode, useEffect, useState } from 'react';
 
-export const useRandomBanner = () => {
+export const useRandomBanner = (randomTitleCases: ReactNode[]) => {
+  const [randomImageSource, setRandomImageSource] = useState('');
+  const [randomTitle, setRandomTitle] = useState<ReactNode | null>(null);
+
   const randomIndex = Math.floor(TOTAL_BANNER_BACKGROUND_SIZE * Math.random()) + 1;
-  const randomImageSource = `/images/main-banner${randomIndex}.png`;
+  const randomTitleIndex = Math.floor(randomTitleCases.length * Math.random());
+  const randomBackgroundSource = `/images/main-banner${randomIndex}.png`;
+
+  useEffect(() => {
+    setRandomImageSource(randomBackgroundSource);
+    setRandomTitle(randomTitleCases[randomTitleIndex]);
+  }, []);
 
   return {
     randomImageSource,
+    randomTitle,
   };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,7 +32,6 @@ const Home = () => {
   const isMounted = useIsMounted();
   const { dialogVisible, toggleDialog } = useDialog();
   const [inputValue, onChangeInput, setInputValue] = useTypeInput('');
-  const { randomImageSource } = useRandomBanner();
   const { data: folderResponse } = useFoldersQuery();
   const { data: postResponse, refetch: fetchPosts } = usePostsByCategoryQuery();
   const { data: incompletedPosts } = useIncompletedPostsQuery();
@@ -62,7 +61,7 @@ const Home = () => {
       풀어보는 시간을 가져볼까요?
     </>,
   ];
-  const randomTitleIndex = Math.floor(randomTitleCases.length * Math.random());
+  const { randomImageSource, randomTitle } = useRandomBanner(randomTitleCases);
 
   useEffect(() => {
     if (currentTab === HOME_TAB_TYPE.EMOTION) {
@@ -180,7 +179,7 @@ const Home = () => {
   return (
     <>
       <HomeHeader />
-      {isMounted && <HomeBanner title={randomTitleCases[randomTitleIndex]} background={randomImageSource} />}
+      {isMounted && <HomeBanner title={randomTitle} background={randomImageSource} />}
       <HomeTabHeader
         currentTab={currentTab}
         isEditMode={isEditMode}
@@ -192,6 +191,7 @@ const Home = () => {
           <FolderList
             isEditMode={isEditMode}
             folderList={folderResponse.folders}
+            thumbnailList={folderResponse.postsThumbnail}
             supportsCollectedFolder={currentTab === HOME_TAB_TYPE.FOLDER}
             onEdit={onEdit}
             onDelete={onDelete}


### PR DESCRIPTION
## Description

Fixes (issue #25)

## Changes

- 메인페이지 **모든 폴더** 영역을 api 에서 전달해주는 postsThumbnail 을 이용하여 작업하는 것으로 변경하였습니다.
  - 기존에는 thumbnail max size 4 와 모든 폴더 배열 length 를 비교하고 slice 하는 작업을 하였는데 제거하였습니다.
  - 다만 아래와 같이 유효한 썸네일인지를 체크하는 작업을 하였습니다. 현재 API 에서 글이 없을 때 default 이미지를 전달해주고 있는데 default 이미지는 프론트에서 노출하면 안되기 때문에 아래와 같이 한번 더 체크하는 작업을 했습니다..!
    (이후 백엔드 협의 요청할 예정이고, 아래 코드는 지워질 것 같습니다.)

  ```jsx
    const validThumbnails = items.map((item, index) => (index < count ? item : ''));
  ```

- randomTitle, randomImageSource hooks 내에서 useEffect hooks 를 이용하여 최초 한번만 실행되게 변경하였습니다.
  - 다른 모달, 버튼 클릭 시 Banner 컴포넌트가 리렌더링 되면서 계속 random 으로 변경되는 버그가 있었습니다.
  - Banner 컴포넌트에 전달되는 props 가 아닌 다른 값들이 변경될 때 Banner 가 리렌더링 되지 않게 최적화 하는 작업도 필요하지만 우선 버그 수정을 위해 위와 같은 작업을 진행하였습니다.

- PostItem 컴포넌트 내에서 태그 갯수 너비에 맞춰서 보여줄 수 있는 태그만 보여줄 수 있게 overflow: hidden 으로 숨김 처리

## 스크린샷
<img width="462" alt="스크린샷 2022-06-04 오후 12 02 25" src="https://user-images.githubusercontent.com/29244798/171977661-0f6641bc-c7d3-458d-8b3b-c0999663781a.png">

**원래 태그 갯수**
<img width="485" alt="스크린샷 2022-06-04 오후 12 27 49" src="https://user-images.githubusercontent.com/29244798/171979211-5a78f7f5-fd64-4b1d-a113-11deeaee7ccb.png">

**너비에 맞게 보일 수 있는 태그만 노출**
<img width="473" alt="스크린샷 2022-06-04 오후 12 27 45" src="https://user-images.githubusercontent.com/29244798/171979207-edbe7282-e940-4e68-b397-e56a99134f2d.png">

