### PR TITLE
previous path 가 기록 작성 페이지일 때, 상세 페이지 버튼 노출 (#132)

### DIFF
--- a/components/Common/AppLayout/AppLayout.tsx
+++ b/components/Common/AppLayout/AppLayout.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
+import { storePathValues } from '@/shared/utils/storePathValues';
+import { useRouter } from 'next/router';
 import { CommonToast } from '@/components/Common';
 import { Container, ContainerInner } from './AppLayout.styles';
 import { toastStateAtom } from '@/store/toast/atom';
@@ -11,8 +13,11 @@ interface AppLayoutProps {
 }
 
 const AppLayout = ({ children }: AppLayoutProps): React.ReactElement => {
+  const router = useRouter();
   const toastType = useRecoilValue(toastStateAtom);
   const dropdownState = useRecoilValue(dropdownStateAtom);
+
+  useEffect(() => storePathValues, [router.asPath]);
 
   return (
     <>

--- a/components/Home/CollectedFolder/CollectedFolder.styles.ts
+++ b/components/Home/CollectedFolder/CollectedFolder.styles.ts
@@ -29,7 +29,7 @@ export const BoxContainer = styled.figure`
   min-height: 16.5rem;
 `;
 
-export const FolderImage = styled.div<{ thumbnail: string }>`
+export const FolderImage = styled.div<{ thumbnail?: string }>`
   border-radius: 1rem;
   padding-top: 100%;
   background-size: cover;

--- a/components/Home/CollectedFolder/CollectedFolder.tsx
+++ b/components/Home/CollectedFolder/CollectedFolder.tsx
@@ -1,3 +1,4 @@
+import { MAX_THUMBNAIL_SIZE } from '@/shared/constants/home';
 import React, { HtmlHTMLAttributes } from 'react';
 import {
   CollectedFolderContainer,
@@ -14,13 +15,16 @@ export interface CollectedFolderProps extends HtmlHTMLAttributes<HTMLDivElement>
 }
 
 const CollectedFolder = ({ count, items, ...rest }: CollectedFolderProps): React.ReactElement => {
-  const validThumbnails = items.map((item, index) => (index < count ? item : ''));
+  const invalidThumbnails = Array(MAX_THUMBNAIL_SIZE - items.length).fill('');
 
   return (
     <CollectedFolderContainer {...rest}>
       <BoxContainer>
-        {validThumbnails.map((item, index) => (
+        {items.map((item, index) => (
           <FolderImage key={index} thumbnail={item} />
+        ))}
+        {invalidThumbnails.map((_, index) => (
+          <FolderImage key={index} />
         ))}
       </BoxContainer>
       <Caption>

--- a/components/Home/Folder/Folder.tsx
+++ b/components/Home/Folder/Folder.tsx
@@ -1,5 +1,6 @@
 import React, { HtmlHTMLAttributes, MouseEvent } from 'react';
 import Image from 'next/image';
+import { commaNumber } from '@/shared/utils/formatter';
 import {
   FolderContainer,
   FolderName,
@@ -77,7 +78,7 @@ const Folder = ({
         {isEditMode && renderEditButton()}
         <div>
           <FolderName>{folderName}</FolderName>
-          <FolderCount>{count}</FolderCount>
+          <FolderCount>{commaNumber(count)}</FolderCount>
         </div>
       </CaptionContainer>
     </FolderContainer>

--- a/components/Post/PostItem/PostItem.tsx
+++ b/components/Post/PostItem/PostItem.tsx
@@ -7,6 +7,7 @@ import { CommonCheckbox, CommonChipButton, CommonTagButton } from '@/components/
 import ArrowRightIcon from 'public/svgs/arrowright.svg';
 import { Post } from '@/shared/type/post';
 import { CONTENT_SEPARATOR } from '@/shared/constants/question';
+import { commaNumber } from '@/shared/utils/formatter';
 
 export interface PostItemProps {
   post: Post;
@@ -56,7 +57,7 @@ const PostItem = ({
       <Content>{firstContent}</Content>
       <CaptionContainer>
         <Caption>{createdAt}</Caption>
-        <Caption>조회수 {views}</Caption>
+        <Caption>조회수 {commaNumber(views)}</Caption>
       </CaptionContainer>
     </PostItemContainer>
   );

--- a/hooks/apis/post/useFirstCategoryQuery.ts
+++ b/hooks/apis/post/useFirstCategoryQuery.ts
@@ -9,6 +9,7 @@ export interface FirstCategoryResponse {
   description: string;
   image: string;
 }
+
 const fetchFirstCategory = async (): Promise<FirstCategoryResponse[]> => {
   const { data } = await fetcher('get', '/api/v1/firstcategory');
 
@@ -16,8 +17,5 @@ const fetchFirstCategory = async (): Promise<FirstCategoryResponse[]> => {
 };
 
 export const useFirstCategoryQuery = () => {
-  return useQuery<FirstCategoryResponse[], Error>(
-    QUERY_KEY.GET_FIRST_CATEGORY,
-    fetchFirstCategory,
-  );
+  return useQuery<FirstCategoryResponse[], Error>(QUERY_KEY.GET_FIRST_CATEGORY, fetchFirstCategory);
 };

--- a/pages/posts/[postId].tsx
+++ b/pages/posts/[postId].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useRouter } from 'next/router';
 import {
   CommonAppBar,
@@ -16,6 +16,7 @@ import useToast from '@/hooks/useToast';
 import { useDeletePostMutation, usePostByIdQuery } from '@/hooks/apis';
 import { useCategoryListQuery } from '@/hooks/apis/post/useCategoryListQuery';
 import { ToastType } from '@/shared/type/common';
+import { getPrevPath } from '@/shared/utils/storePathValues';
 import { CommonTextArea } from '@/components/Common';
 import BottomSheetList from '@/components/BottomSheetList/BottomSheetList';
 import DialogWarning from '@/components/Dialog/DialogWarning';
@@ -27,6 +28,8 @@ import {
   MultipleLineText,
   QuestionContainer,
 } from '@/components/Post/PostDetail.style';
+import PostFloatingButton from '@/components/Post/FloatingButton';
+import { commaNumber } from '@/shared/utils/formatter';
 
 const PostDetail = () => {
   const router = useRouter();
@@ -36,7 +39,7 @@ const PostDetail = () => {
   const deletePostMutation = useDeletePostMutation();
   const notify = useToast();
 
-  const { data: post, refetch: fetchPost } = usePostByIdQuery(postId);
+  const { data: post } = usePostByIdQuery(postId);
   const { data: categories } = useCategoryListQuery();
 
   const folderId = router.query.folderId ? Number(router.query.folderId) : 0;
@@ -68,17 +71,12 @@ const PostDetail = () => {
     return '';
   };
 
-  useEffect(() => {
-    if (postId) {
-      fetchPost();
-    }
-  }, [fetchPost, postId]);
-
   // TODO: 오류 페이지 이후 작업 요청해서 바꾸기..
   if (!post || !postId) return <div>404</div>;
 
   const hasMultipleContent = post.content.includes(CONTENT_SEPARATOR);
   const contents = post.content.split(CONTENT_SEPARATOR);
+  const isFromWritePage = getPrevPath() === '/write';
 
   const onDelete = () => {
     deletePostMutation.mutate([postId], {
@@ -148,9 +146,10 @@ const PostDetail = () => {
         ) : (
           <CommonTextArea value={post.content} height="42.2rem" readOnly />
         )}
-        <Description>조회수 {post.views || 0}</Description>
+        <Description>조회수 {commaNumber(post.views)}</Description>
         <Description>{post.createdAt}</Description>
       </PostDetailContainer>
+      {isFromWritePage && <PostFloatingButton />}
       {isVisibleSheet && (
         <CommonBottomSheetContainer
           onClose={() => toggleSheet()}

--- a/shared/utils/formatter.ts
+++ b/shared/utils/formatter.ts
@@ -1,0 +1,5 @@
+const commaNumber = (value: number) => {
+  return value ? value.toLocaleString() : '0';
+};
+
+export { commaNumber };

--- a/shared/utils/formatter.ts
+++ b/shared/utils/formatter.ts
@@ -1,3 +1,7 @@
+/**
+ * @param {number} 1000
+ * @return {string} '1,000'
+ */
 const commaNumber = (value: number) => {
   return value ? value.toLocaleString() : '0';
 };

--- a/shared/utils/storePathValues.ts
+++ b/shared/utils/storePathValues.ts
@@ -1,0 +1,14 @@
+const storePathValues = () => {
+  const storage = globalThis?.sessionStorage;
+  if (!storage) return;
+  const prevPath = storage.getItem('currentPath');
+  storage.setItem('prevPath', prevPath as string);
+  storage.setItem('currentPath', globalThis.location.pathname);
+};
+
+const getPrevPath = () => {
+  const storage = globalThis?.sessionStorage;
+  return storage ? storage.getItem('prevPath') : '';
+};
+
+export { storePathValues, getPrevPath };


### PR DESCRIPTION
## Description

Fixes (issue #132)

기록 작성 후, 상세페이지 내에 홈으로 돌아가기 버튼이 노출되어야 하는 이슈가 있습니다.

## Changes

- storePathValues 함수 추가 (ref. https://www.grouparoo.com/blog/getting-previous-path-nextjs)
  - sessionStorage 에 prevPath, currentPath 를 저장하여 previous path 를 유지하는 작업을 추가하였습니다.
- AppLayout 에서 storePathValues 실행
  - 현재는 /write -> post detail 페이지로 이동할 때만 previous path 를 알면 되지만, 전체적인 구조를 봤을 때 특정 페이지가 아닌 AppLayout 에서 실행하는게 맞는 것 같아서 AppLayout 에 추가하였습니다!

- `commaNumber` 함수 추가
  - 조회수, 폴더 글 갯수와 같이 숫자 포맷팅을 하기 위해 추가하였습니다.

- 메인 페이지 모든 폴더 컴포넌트 버그 수정
  - api response 가 변경되면서 맞춰주기 위해 로직을 변경하였습니다.

## 스크린샷
<img width="400" alt="스크린샷 2022-06-06 오후 5 32 25" src="https://user-images.githubusercontent.com/29244798/172125735-d54b0cbc-1772-4d1d-a709-2bded148dbab.png">
<img width="400" alt="스크린샷 2022-06-06 오후 5 32 38" src="https://user-images.githubusercontent.com/29244798/172125753-357a129d-85bd-4ab6-bb83-86e4e8185ea4.png">
<img width="397" alt="스크린샷 2022-06-06 오후 5 31 16" src="https://user-images.githubusercontent.com/29244798/172125760-95fe43d4-a2ec-48fb-91e7-67a9caa4aaae.png">

