### PR TITLE
수정 페이지 내 감정 선택하는 컴포넌트 수정 (#35)

### DIFF
--- a/components/BottomSheetCategoryList/BottomSheetCategoryList.tsx
+++ b/components/BottomSheetCategoryList/BottomSheetCategoryList.tsx
@@ -1,14 +1,10 @@
+import { CategoryListItemResponse } from '@/hooks/apis';
 import React from 'react';
 import styled from 'styled-components';
 import { CommonButton } from '../Common';
 
-interface CategoryItem {
-  id: string;
-  label: string;
-}
-
 interface BottomSheetCategoryListProps {
-  items: CategoryItem[];
+  items: CategoryListItemResponse[];
   selectedItem: string;
   onClick: (id: string) => void;
 }
@@ -16,14 +12,14 @@ interface BottomSheetCategoryListProps {
 const BottomSheetCategoryList = ({ items, selectedItem, onClick }: BottomSheetCategoryListProps) => {
   return (
     <BottomSheetListContainer>
-      {items.map((item: CategoryItem) => (
+      {items.map((item: CategoryListItemResponse) => (
         <CommonButton
-          key={item.id}
+          key={item.categoryId}
           size="medium"
-          color={selectedItem === item.id ? 'primary' : 'gray'}
-          onClick={() => onClick(item.id)}
+          color={selectedItem === item.categoryName ? 'primary' : 'gray'}
+          onClick={() => onClick(item.categoryName)}
         >
-          {item.label}
+          {item.description}
         </CommonButton>
       ))}
     </BottomSheetListContainer>

--- a/components/CategorySelector/CategorySelector.stories.tsx
+++ b/components/CategorySelector/CategorySelector.stories.tsx
@@ -17,8 +17,10 @@ Default.args = {
   title: '기록 이전 감정',
   options: [
     {
-      id: 'JOY',
-      label: '기뻐요',
+      categoryId: 1,
+      categoryName: 'JOY',
+      description: '기뻐요',
+      image: '',
     },
   ],
   disabled: false,

--- a/components/CategorySelector/CategorySelector.tsx
+++ b/components/CategorySelector/CategorySelector.tsx
@@ -1,20 +1,15 @@
+import React, { ButtonHTMLAttributes } from 'react';
 import theme from '@/styles/theme';
-import React, { ChangeEventHandler } from 'react';
 import Image from 'next/image';
 import styled, { css } from 'styled-components';
 import { EMOTION_COLOR_TYPE } from '@/shared/constants/category';
+import { CategoryListItemResponse } from '@/hooks/apis';
 
-interface SelectOption {
-  id: string;
-  label: string;
-}
-
-export interface CategorySelectorProps {
+export interface CategorySelectorProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   selectedValue: string;
   title: string;
-  options: SelectOption[];
   disabled?: boolean;
-  onChange?: ChangeEventHandler<HTMLSelectElement>;
+  options: CategoryListItemResponse[];
 }
 
 const CategorySelector = ({
@@ -22,47 +17,31 @@ const CategorySelector = ({
   title,
   options,
   disabled = false,
-  onChange,
+  ...rest
 }: CategorySelectorProps): React.ReactElement => {
+  const selectedCategoryDescription = options
+    ? options.find((option) => option.categoryName === selectedValue)?.description
+    : '';
+
   return (
-    <CategorySelectorContainer backgroundColor={EMOTION_COLOR_TYPE[selectedValue]} disabled={disabled}>
+    <CategorySelectorContainer backgroundColor={EMOTION_COLOR_TYPE[selectedValue]} disabled={disabled} {...rest}>
       <Title>{title}</Title>
-      <SelectContainer
-        backgroundColor={EMOTION_COLOR_TYPE[selectedValue]}
-        disabled={disabled}
-        value={selectedValue}
-        onChange={onChange}
-      >
-        {options.map(({ id, label }, index) => {
-          return (
-            <Option key={index} value={id}>
-              {label}
-            </Option>
-          );
-        })}
-      </SelectContainer>
+      <Description backgroundColor={EMOTION_COLOR_TYPE[selectedValue]}>{selectedCategoryDescription}</Description>
       <ImageContainer>
         <Image src={`/svgs/mood-${selectedValue.toLowerCase()}.svg`} alt="" width={64} height={64} />
       </ImageContainer>
-      <ArrowIcon width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path
-          d="M14.5967 5.98584L8.59668 11.9858L2.59668 5.98584"
-          stroke="#121212"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </ArrowIcon>
     </CategorySelectorContainer>
   );
 };
 
-const CategorySelectorContainer = styled.div<{ backgroundColor: string; disabled: boolean }>`
+const CategorySelectorContainer = styled.button<{ backgroundColor: string; disabled: boolean }>`
   display: inline-flex;
   position: relative;
   width: 100%;
   border-radius: 1.4rem;
   background-color: ${(props) => props.backgroundColor};
+  text-align: left;
+  color: ${theme.colors.black};
 
   ${(props) =>
     props.disabled &&
@@ -76,20 +55,13 @@ const Title = styled.span`
   top: 1.2rem;
   left: 2.4rem;
   ${theme.fonts.caption1};
-  color: ${theme.colors.black};
 `;
 
-const SelectContainer = styled.select<{ backgroundColor: string }>`
-  width: 100%;
+const Description = styled.span<{ backgroundColor: string }>`
   padding: 3.2rem 2.4rem 1.2rem;
   font-size: 1.6rem;
   font-weight: bold;
   line-height: 1.9rem;
-  border-radius: 1.4rem;
-  color: ${theme.colors.black};
-  background-color: ${(props) => props.backgroundColor};
-  border: none;
-  appearance: none;
 `;
 
 const ImageContainer = styled.div`
@@ -100,14 +72,6 @@ const ImageContainer = styled.div`
   img {
     mix-blend-mode: overlay;
   }
-`;
-
-const Option = styled.option``;
-
-const ArrowIcon = styled.svg`
-  position: absolute;
-  right: 3.85rem;
-  top: 3rem;
 `;
 
 export default CategorySelector;

--- a/components/CurrentEmotion/CurrentEmotion.tsx
+++ b/components/CurrentEmotion/CurrentEmotion.tsx
@@ -62,7 +62,8 @@ const CurrentEmotion = () => {
   const { mutate: createPost } = useMutation((postData: PostRequestType) => postService.createPost(postData), {
     onSuccess: (data) => {
       queryClient.invalidateQueries(QUERY_KEY.CREATE_POST);
-      queryClient.resetQueries(QUERY_KEY.GET_POST_BY_ID);
+      queryClient.invalidateQueries(QUERY_KEY.GET_POST_BY_ID);
+      queryClient.invalidateQueries(QUERY_KEY.GET_FOLDERS);
       nextProgressStep();
       setPostId(data as unknown as PostResponseType);
     },

--- a/components/CurrentEmotion/CurrentEmotion.tsx
+++ b/components/CurrentEmotion/CurrentEmotion.tsx
@@ -62,6 +62,7 @@ const CurrentEmotion = () => {
   const { mutate: createPost } = useMutation((postData: PostRequestType) => postService.createPost(postData), {
     onSuccess: (data) => {
       queryClient.invalidateQueries(QUERY_KEY.CREATE_POST);
+      queryClient.resetQueries(QUERY_KEY.GET_POST_BY_ID);
       nextProgressStep();
       setPostId(data as unknown as PostResponseType);
     },

--- a/components/Post/PostEdit.style.ts
+++ b/components/Post/PostEdit.style.ts
@@ -14,7 +14,7 @@ export const SelectContainer = styled.div`
   display: flex;
   margin: -2.6rem 0 2.4rem;
 
-  div ~ div {
+  button ~ button {
     margin-left: 1.6rem;
   }
 `;

--- a/pages/posts/[postId]/edit.tsx
+++ b/pages/posts/[postId]/edit.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, ChangeEvent } from 'react';
+import React, { useCallback, useEffect, ChangeEvent, useState } from 'react';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
 import { CONTENT_SEPARATOR } from '@/shared/constants/question';
@@ -48,6 +48,7 @@ import Whiteadd from 'public/svgs/whiteadd.svg';
 import FolderIcon from 'public/svgs/folder.svg';
 import FolderPlus from 'public/svgs/folderplus.svg';
 import usePostEditForm from '@/hooks/post/usePostEditForm';
+import { commaNumber } from '@/shared/utils/formatter';
 
 const PostDetail = () => {
   const router = useRouter();
@@ -64,6 +65,7 @@ const PostDetail = () => {
   const [folderName, onChangeFolderName] = useTypeInput('');
 
   const { isVisibleSheet, toggleSheet, calcBottomSheetHeight } = useBottomSheet();
+  const [bottomSheetType, setBottomSheetType] = useState('');
   const { dialogVisible, toggleDialog } = useDialog();
 
   const { data: folderListData } = useFoldersQuery();
@@ -81,11 +83,7 @@ const PostDetail = () => {
     });
   }, [createFolder, folderName, toggleDialog]);
 
-  const categoryOptions = categories
-    ? Object.values(categories)
-        .flat()
-        .map((category) => ({ id: category.categoryName, label: category.description }))
-    : [];
+  const categoryOptions = categories ? Object.values(categories).flat() : [];
 
   const getFolderName = (id: number) => folderListData?.folders.find(({ folderId }) => folderId === id)?.folderName;
 
@@ -105,14 +103,13 @@ const PostDetail = () => {
   useEffect(() => {
     if (!router.isReady) return;
 
-    // TODO: DONTKNOW 상수로 분리 or API response 에 있는 것으로 변경해야 합니다.
-    if (secondCategory === 'DONTKNOW') {
-      toggleSheet();
+    if (selectedState.secondCategory === 'DONTKNOW') {
+      !isVisibleSheet && showCategoryBottomSheet();
     }
 
     fetchPostById();
     fetchFolderByPostId();
-  }, [router.isReady, secondCategory, fetchPostById]);
+  }, [router.isReady, selectedState]);
 
   useEffect(() => {
     if (post) {
@@ -121,14 +118,12 @@ const PostDetail = () => {
       setTagList(post?.tags);
 
       const contents = post.content.split(CONTENT_SEPARATOR);
-
       if (hasMultipleContent) {
         setFirstContent(contents[0]);
         setSecondContent(contents[1]);
         setThirdContent(contents[2]);
         return;
       }
-
       setFirstContent(post.content);
     }
   }, [
@@ -158,22 +153,26 @@ const PostDetail = () => {
     );
   };
 
-  const bottomSheetHeight =
-    secondCategory === 'DONTKNOW' ? calcBottomSheetHeight({ folderSize: 4, hasHeader: true }) : 364;
-  const headerTitle =
-    secondCategory === 'DONTKNOW' ? (
-      <div>시간이 지난 지금, 감정에 변화가 있었나요?</div>
-    ) : (
-      <>
-        <Image src={FolderIcon} alt="folderIcon" />
-        <div>폴더를 선택해주세요.</div>
-      </>
-    );
+  const isCategoryBottomSheet = bottomSheetType === 'category';
+  const bottomSheetHeight = isCategoryBottomSheet ? calcBottomSheetHeight({ folderSize: 4, hasHeader: true }) : 364;
+  const headerTitle = isCategoryBottomSheet ? (
+    <div>글을 기록한 이후 어떤 감정을 느꼈나요?</div>
+  ) : (
+    <>
+      <Image src={FolderIcon} alt="folderIcon" />
+      <div>폴더를 선택해주세요.</div>
+    </>
+  );
+
+  const showCategoryBottomSheet = () => {
+    setBottomSheetType('category');
+    toggleSheet();
+  };
 
   const renderBottomSheet = () => {
     return (
       <CommonBottomSheetContainer onClose={toggleSheet} BottomSheetHeight={bottomSheetHeight} headerTitle={headerTitle}>
-        {secondCategory === 'DONTKNOW' ? (
+        {isCategoryBottomSheet ? (
           <BottomSheetCategoryList
             items={categoryOptions}
             selectedItem={selectedState.secondCategory}
@@ -228,7 +227,7 @@ const PostDetail = () => {
             title="기록 이후 감정"
             selectedValue={selectedState.secondCategory}
             options={categoryOptions}
-            onChange={(e) => handleCategoryClick(e.target.value)}
+            onClick={showCategoryBottomSheet}
           />
         </SelectContainer>
         {hasMultipleContent ? (
@@ -263,7 +262,7 @@ const PostDetail = () => {
         ) : (
           <CommonTextArea value={firstContent} height="42.2rem" onChange={onChangeFirstContent} />
         )}
-        <Description>조회수 {post.views || 0}</Description>
+        <Description>조회수 {commaNumber(post.views)}</Description>
         <Description>{post.createdAt}</Description>
         <SpaceBetweenContainer>
           <OptionTitle>공개</OptionTitle>

--- a/pages/posts/[postId]/edit.tsx
+++ b/pages/posts/[postId]/edit.tsx
@@ -53,7 +53,6 @@ import { commaNumber } from '@/shared/utils/formatter';
 const PostDetail = () => {
   const router = useRouter();
   const postId = router.query.postId as string;
-  const secondCategory = router.query.secondCategory as string;
 
   const { selectedState, setSelectedState, hasMultipleContent, changePostForm, handleCategoryClick } =
     usePostEditForm();

--- a/pages/posts/dontknow-feelings.tsx
+++ b/pages/posts/dontknow-feelings.tsx
@@ -3,15 +3,14 @@ import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import Image from 'next/image';
 import theme from '@/styles/theme';
-import { Post } from '@/shared/type/post';
 import PostItem from '@/components/Post/PostItem/PostItem';
 import { CommonAppBar, CommonIconButton } from '@/components/Common';
 import ListEmpty from 'public/images/list-empty.png';
-
-const postList: Post[] = [];
+import { useIncompletedPostsQuery } from '@/hooks/apis';
 
 const PostList = () => {
   const router = useRouter();
+  const { data: postList = [] } = useIncompletedPostsQuery();
 
   return (
     <>
@@ -27,9 +26,7 @@ const PostList = () => {
         </Title>
         {postList.length ? (
           postList.map((post) => (
-            <li key={post.id}>
-              <PostItem post={post} isMine={false} onClick={() => router.push(`/posts/${post.id}`)} />
-            </li>
+            <PostItem key={post.id} post={post} isMine={false} onClick={() => router.push(`/posts/${post.id}`)} />
           ))
         ) : (
           <EmptyContainer>


### PR DESCRIPTION
## Description

Fixes (issue #35)

## Changes

- CategorySelector 컴포넌트 select -> button 으로 변경
   - select 에서 button 으로 변경하면서 category list 데이터 구조를 변경하지 않아도 되서 options interface 를 변경하였습니다.

- 모르겠어요 선택한 기록 리스트 페이지 API 연결 작업

## 스크린샷

**CategorySelector 컴포넌트 내 arrow-icon 제거**
<img width="394" alt="스크린샷 2022-06-06 오후 5 46 15" src="https://user-images.githubusercontent.com/29244798/172127977-0aab6c1f-dfe4-4c87-b154-d2dcc3f26695.png">

**CategorySelector 클릭 시, 하단 바텀시트 노출**
<img width="437" alt="스크린샷 2022-06-06 오후 5 46 25" src="https://user-images.githubusercontent.com/29244798/172127983-ba6dd915-b67c-49bf-a928-b47c60aa7051.png">

