### PR TITLE
메인페이지, 리스트 페이지, 상세 페이지 관련 QA 이슈 해결

### DIFF
--- a/components/Common/TextArea/TextArea.styles.ts
+++ b/components/Common/TextArea/TextArea.styles.ts
@@ -2,9 +2,7 @@ import styled from 'styled-components';
 import { TextAreaProps } from '@/components/Common/TextArea/TextArea';
 import theme from '@/styles/theme';
 
-export const Textarea = styled.textarea<
-  Pick<TextAreaProps, 'height' | 'borderRadius'>
->`
+export const Textarea = styled.textarea<Pick<TextAreaProps, 'height' | 'borderRadius'>>`
   width: 100%;
   padding: 1.6rem 1.8rem 1.8rem 1.8rem;
   display: inline-block;
@@ -12,7 +10,7 @@ export const Textarea = styled.textarea<
   cursor: text;
   height: ${({ height }) => height};
   border-radius: ${({ borderRadius }) => borderRadius};
-  background: ${theme.colors.gray3};
+  background: ${theme.colors.gray2};
   border: none;
   right: 0;
   ${theme.fonts.body}

--- a/components/Dialog/DialogFolderForm.tsx
+++ b/components/Dialog/DialogFolderForm.tsx
@@ -9,11 +9,7 @@ interface DialogFolderFormProps {
   onChange: ChangeEventHandler<HTMLInputElement>;
 }
 
-const DialogFolderForm = ({
-  isEditMode = false,
-  value,
-  onChange,
-}: DialogFolderFormProps) => {
+const DialogFolderForm = ({ isEditMode = false, value, onChange }: DialogFolderFormProps) => {
   const dialogTitle = isEditMode ? '변경할 폴더를' : '새폴더의 이름을';
 
   return (
@@ -27,6 +23,7 @@ const DialogFolderForm = ({
         value={value}
         hasBorder={true}
         onChange={onChange}
+        autoFocus
         hasRightSideIcon
       />
     </DialogContainer>

--- a/components/Home/CollectedFolder/CollectedFolder.tsx
+++ b/components/Home/CollectedFolder/CollectedFolder.tsx
@@ -28,7 +28,7 @@ const CollectedFolder = ({ count, items, ...rest }: CollectedFolderProps): React
         ))}
       </BoxContainer>
       <Caption>
-        <FolderName>모든 폴더</FolderName>
+        <FolderName>모든 기록</FolderName>
         <FolderCount>{count}</FolderCount>
       </Caption>
     </CollectedFolderContainer>

--- a/components/Home/Folder/Folder.tsx
+++ b/components/Home/Folder/Folder.tsx
@@ -19,9 +19,9 @@ export interface FolderProps extends HtmlHTMLAttributes<HTMLDivElement> {
   count: number;
   coverImage: string;
   isEditMode?: boolean;
-  supportsMultipleLayout?: boolean;
-  onClick: () => void;
-  onEdit?: (id: number) => void;
+  supportsEmptyImg?: boolean;
+  onClick: (id: number) => void;
+  onEdit?: (id: number, name: string) => void;
   onDelete?: (id: number) => void;
 }
 
@@ -31,6 +31,7 @@ const Folder = ({
   folderName,
   coverImage,
   isEditMode = false,
+  supportsEmptyImg = false,
   onClick,
   onEdit,
   onDelete,
@@ -46,7 +47,16 @@ const Folder = ({
     if (!onEdit) return;
 
     e.stopPropagation();
-    onEdit(folderId);
+    onEdit(folderId, folderName);
+  };
+
+  const handleClick = (e: MouseEvent<HTMLSpanElement>) => {
+    if (isEditMode) {
+      e.stopPropagation();
+      return;
+    }
+
+    onClick(folderId);
   };
 
   const renderDeleteButton = () => {
@@ -71,7 +81,7 @@ const Folder = ({
 
   return (
     <FolderContainer>
-      <BoxContainer onClick={onClick} backgroundImage={count !== 0 ? coverImage : ''}>
+      <BoxContainer onClick={handleClick} backgroundImage={!supportsEmptyImg || count !== 0 ? coverImage : ''}>
         {isEditMode && renderDeleteButton()}
       </BoxContainer>
       <CaptionContainer>

--- a/components/Home/Folder/Folder.tsx
+++ b/components/Home/Folder/Folder.tsx
@@ -1,4 +1,4 @@
-import React, { HtmlHTMLAttributes, MouseEvent } from 'react';
+import React, { MouseEvent } from 'react';
 import Image from 'next/image';
 import { commaNumber } from '@/shared/utils/formatter';
 import {
@@ -13,7 +13,7 @@ import {
 import TrashIcon from 'public/svgs/trash.svg';
 import EditFolderIcon from 'public/svgs/editfolder.svg';
 
-export interface FolderProps extends HtmlHTMLAttributes<HTMLDivElement> {
+export interface FolderProps {
   folderId: number;
   folderName: string;
   count: number;
@@ -50,7 +50,7 @@ const Folder = ({
     onEdit(folderId, folderName);
   };
 
-  const handleClick = (e: MouseEvent<HTMLSpanElement>) => {
+  const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     if (isEditMode) {
       e.stopPropagation();
       return;

--- a/components/Home/FolderList/FolderList.tsx
+++ b/components/Home/FolderList/FolderList.tsx
@@ -46,7 +46,7 @@ const FolderList = ({
           count={folder.postCount}
           coverImage={folder.coverImg}
           isEditMode={isEditMode && !folder.default}
-          onClick={() => onClick(folder.folderId)}
+          onClick={onClick}
           onEdit={onEdit}
           onDelete={onDelete}
         />

--- a/components/Home/FolderList/FolderList.tsx
+++ b/components/Home/FolderList/FolderList.tsx
@@ -9,7 +9,7 @@ interface FolderListProps {
   folderList: Folder[];
   thumbnailList?: string[];
   supportsCollectedFolder: boolean;
-  onEdit: (id: number) => void;
+  onEdit: (id: number, name: string) => void;
   onDelete: (id: number) => void;
 }
 
@@ -28,6 +28,10 @@ const FolderList = ({
     router.push('/posts');
   };
 
+  const onClick = (folderId: number) => {
+    router.push(`/posts?folderId=${folderId}`);
+  };
+
   return (
     <>
       {supportsCollectedFolder && (
@@ -35,13 +39,14 @@ const FolderList = ({
       )}
       {folderList.map((folder) => (
         <HomeFolder
+          supportsEmptyImg={supportsCollectedFolder}
           key={folder.folderId}
           folderId={folder.folderId}
           folderName={folder.folderName}
           count={folder.postCount}
           coverImage={folder.coverImg}
           isEditMode={isEditMode && !folder.default}
-          onClick={() => router.push(`/posts?folderId=${folder.folderId}`)}
+          onClick={() => onClick(folder.folderId)}
           onEdit={onEdit}
           onDelete={onDelete}
         />

--- a/hooks/apis/post/usePostsQuery.ts
+++ b/hooks/apis/post/usePostsQuery.ts
@@ -29,7 +29,7 @@ const usePostsByFolderIdQuery = ({
   );
 
 const usePostByIdQuery = (id: string): UseQueryResult<Post, AxiosError<ServerResponse>> =>
-  useQuery(QUERY_KEY.GET_POST_BY_ID, () => postService.getPostById(id), { enabled: !!id });
+  useQuery(QUERY_KEY.GET_POST_BY_ID, () => postService.getPostById(id), { enabled: !!id, refetchOnMount: true });
 
 const usePostsByCategoryQuery = (): UseQueryResult<CategoryFolder[], AxiosError<ServerResponse>> =>
   useQuery(QUERY_KEY.GET_POSTS_BY_CATEGORIES, postService.getPostsByCategories);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -77,9 +77,10 @@ const Home = () => {
     toggleDialog();
   };
 
-  const onEdit = (id: number) => {
+  const onEdit = (id: number, name: string) => {
     setDialogType('edit');
     toggleDialog();
+    setInputValue(name);
     setSelectedFolderId(id);
   };
 
@@ -87,6 +88,11 @@ const Home = () => {
     setDialogType('delete');
     toggleDialog();
     setSelectedFolderId(id);
+  };
+
+  const onCloseDialog = () => {
+    toggleDialog();
+    setInputValue('');
   };
 
   const createFolder = () => {
@@ -99,10 +105,10 @@ const Home = () => {
         setInputValue('');
         toggleDialog();
       },
-      onError: () => {
+      onError: (error) => {
         notify({
           type: ToastType.ERROR,
-          message: '이미 중복된 폴더명이에요.',
+          message: (error as AxiosError).response?.data.msg,
         });
       },
     });
@@ -149,7 +155,7 @@ const Home = () => {
         return (
           <CommonDialog
             type="modal"
-            onClose={toggleDialog}
+            onClose={onCloseDialog}
             disabledConfirm={inputValue === ''}
             onConfirm={createFolder}
           >
@@ -160,7 +166,7 @@ const Home = () => {
         return (
           <CommonDialog
             type="modal"
-            onClose={toggleDialog}
+            onClose={onCloseDialog}
             disabledConfirm={inputValue === ''}
             onConfirm={() => editFolder(selectedFolderId)}
           >

--- a/pages/posts/[postId].tsx
+++ b/pages/posts/[postId].tsx
@@ -124,7 +124,7 @@ const PostDetail = () => {
               <MultipleLineText>
                 카톡이름님에게 <br /> 어떤 일이 있었나요?
               </MultipleLineText>
-              <CommonTextArea value={contents[0]} height="32.6rem" readOnly />
+              <CommonTextArea value={contents[0]} height="32.6rem" disabled />
             </ProvidedQuestionWrap>
             <ProvidedQuestionWrap>
               <NumberTitle>
@@ -132,7 +132,7 @@ const PostDetail = () => {
                 /3
               </NumberTitle>
               <ProvidedQuestionMainTitle>그 때 어떤 감정이 들었나요?</ProvidedQuestionMainTitle>
-              <CommonTextArea value={contents[1]} height="32.6rem" readOnly />
+              <CommonTextArea value={contents[1]} height="32.6rem" disabled />
             </ProvidedQuestionWrap>
             <ProvidedQuestionWrap>
               <NumberTitle>
@@ -140,11 +140,11 @@ const PostDetail = () => {
                 /3
               </NumberTitle>
               <ProvidedQuestionMainTitle>고생했어요! 스스로에게 한마디를 쓴다면?</ProvidedQuestionMainTitle>
-              <CommonTextArea value={contents[2]} height="32.6rem" readOnly />
+              <CommonTextArea value={contents[2]} height="32.6rem" disabled />
             </ProvidedQuestionWrap>
           </QuestionContainer>
         ) : (
-          <CommonTextArea value={post.content} height="42.2rem" readOnly />
+          <CommonTextArea value={post.content} height="42.2rem" disabled />
         )}
         <Description>조회수 {commaNumber(post.views)}</Description>
         <Description>{post.createdAt}</Description>

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -34,7 +34,7 @@ const PostListPage = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [checkedItems, setCheckedItems] = useState<string[]>([]);
   const [dialogType, setDialogType] = useState('');
-  const [inputValue, onChangeInput] = useTypeInput('');
+  const [inputValue, onChangeInput, setInputValue] = useTypeInput('');
   const folderId = Number(router.query.folderId);
   const categoryId = Number(router.query.categoryId);
 
@@ -74,35 +74,6 @@ const PostListPage = () => {
     },
   });
 
-  const categoryBottomSheetItems = [
-    {
-      label: '기록 선택하기',
-      onClick: () => {
-        setIsEditing(true);
-        toggleSheet();
-      },
-    },
-  ];
-  const folderBottomSheetItems = [
-    ...categoryBottomSheetItems,
-    {
-      label: '폴더명 변경하기',
-      onClick: () => {
-        setDialogType('edit');
-        toggleDialog();
-        toggleSheet();
-      },
-    },
-    {
-      label: '폴더 삭제하기',
-      onClick: () => {
-        setDialogType('delete');
-        toggleDialog();
-        toggleSheet();
-      },
-    },
-  ];
-
   useEffect(() => {
     if (router.isReady) {
       fetch();
@@ -134,6 +105,7 @@ const PostListPage = () => {
             message: '폴더이름이 변경되었습니다.',
           });
           toggleDialog();
+          fetch();
         },
       },
     );
@@ -159,6 +131,37 @@ const PostListPage = () => {
   const postData = postResponse?.pages || [{ posts: [], folderName: '', totalCount: 0 }];
   const { folderName, totalCount } = postData[0];
 
+  const categoryBottomSheetItems = [
+    {
+      label: '기록 선택하기',
+      onClick: () => {
+        setIsEditing(true);
+        toggleSheet();
+      },
+    },
+  ];
+
+  const folderBottomSheetItems = [
+    ...categoryBottomSheetItems,
+    {
+      label: '폴더명 변경하기',
+      onClick: () => {
+        setDialogType('edit');
+        setInputValue(folderName as string);
+        toggleDialog();
+        toggleSheet();
+      },
+    },
+    {
+      label: '폴더 삭제하기',
+      onClick: () => {
+        setDialogType('delete');
+        toggleDialog();
+        toggleSheet();
+      },
+    },
+  ];
+
   const getBottomSheetItems = () => {
     return folderId && folderName !== '미분류' ? folderBottomSheetItems : categoryBottomSheetItems;
   };
@@ -172,7 +175,7 @@ const PostListPage = () => {
       <CommonAppBar>
         <CommonAppBar.Left>
           <CommonIconButton iconName="left" alt="이전" onClick={() => router.back()} />
-          <HeaderTitle>{folderName}</HeaderTitle>
+          <HeaderTitle>{folderName || '모든 기록'}</HeaderTitle>
         </CommonAppBar.Left>
         <CommonAppBar.Right>
           {isEditing ? (


### PR DESCRIPTION
## Description

https://www.notion.so/depromeet/QA-27c48bd47fd94b6f94e17b464532caeb
노션에 있는 QA 이슈 해결

## Changes

**style**
- Textarea component background 수정

**fix**
- 모든 폴더 -> 모든 기록으로 키워드 변경
- 상세 페이지에서 Textarea 에 focus 할 수 없게 변경 (readonly -> disabled 로 변경)
- 폴더 편집 시, 폴더 변경 팝업에 기본 폴더명 노출되게 수정
- 폴더 변경/추가 팝업 닫을 때, inputValue 초기화 작업
- 폴더 리스트에서 폴더 변경 시, refetch 실행

**기능 개선**
- 폴더 추가/변경 팝업 노출 시, autoFocus 되게 attribute 추가
