### PR TITLE
fix: safari에서 navigator.clipboard 지원하지 않아 클립보드 카피 방법 수정

### DIFF
--- a/shared/utils/copyClipboard.ts
+++ b/shared/utils/copyClipboard.ts
@@ -8,9 +8,20 @@ export const copyClipboard = async ({
   onFail?: () => void;
 }) => {
   try {
-    await navigator.clipboard.writeText(text);
+    const inputHasClipboardText = <HTMLInputElement>document.createElement('input');
+    inputHasClipboardText.id = 'clipboardText';
+
+    document.body.appendChild(inputHasClipboardText);
+    if (!inputHasClipboardText) return alert(404);
+    inputHasClipboardText.value = text;
+    inputHasClipboardText.setSelectionRange(0, text.length);
+    inputHasClipboardText.select();
+    document.execCommand('copy');
+    document.body.removeChild(inputHasClipboardText);
+
     onSuccess?.();
   } catch (error) {
+    console.log(error);
     onFail?.();
   }
 };


### PR DESCRIPTION
## Description

사파리에서 클립보드 복사가 되지 않아 방식을 수정했습니다. deprecated 된 방식이지만 QA를 위해 우선 수정하고 추후에 다른 방법을 찾아 적용 할 수 있도록 하겠습니다.

<!-- 해당 Pull Request에 대한 설명을 해주세요.
해당 Pull Request로 무엇을 성취했는지 간단하게 설명해주세요. 
만약 새롭게 추가한 package(s)가 있다면 기입해주세요.
-->

Fixes (issue #161 )

## Changes

<!-- 리뷰어를 위해 변경 사항에 대해 설명해주세요. -->

- navigator.clipboard 대신 document. execCommand 방식으로 수정 

## Checklist

✅ 이슈 번호를 올바르게 기입했나요? 만약 관련 이슈가 존재하지 않는다면 체크해주세요. 
