### PR TITLE
메인페이지 스타일 수정, 폴더 리스트 페이지 앱바 수정 

### DIFF
--- a/components/Home/CollectedFolder/CollectedFolder.styles.ts
+++ b/components/Home/CollectedFolder/CollectedFolder.styles.ts
@@ -25,15 +25,13 @@ export const BoxContainer = styled.figure`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 0.4rem;
-  height: calc(100% - 4.2rem);
-  min-height: 16.5rem;
 `;
 
 export const FolderImage = styled.div<{ thumbnail?: string }>`
   border-radius: 1rem;
   padding-top: 100%;
   background-size: cover;
-  background-color: ${theme.colors.gray3};
+  background-color: ${theme.colors.gray2};
   ${(props) =>
     props.thumbnail &&
     css`

--- a/components/Home/FloatingButton/FloatingButton.tsx
+++ b/components/Home/FloatingButton/FloatingButton.tsx
@@ -50,6 +50,10 @@ const FloatingContainer = styled.div<{ isHidden: boolean }>`
   > div {
     width: 22.3rem;
     margin: 0 auto;
+
+    button {
+      box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.3);
+    }
   }
 `;
 

--- a/pages/posts/[postId]/edit.tsx
+++ b/pages/posts/[postId]/edit.tsx
@@ -247,8 +247,7 @@ const PostDetail = () => {
           <QuestionContainer>
             <ProvidedQuestionWrap>
               <NumberTitle>
-                <span>1</span>
-                /3
+                <span>1</span>/3
               </NumberTitle>
               <MultipleLineText>
                 카톡이름님에게 <br /> 어떤 일이 있었나요?
@@ -257,16 +256,14 @@ const PostDetail = () => {
             </ProvidedQuestionWrap>
             <ProvidedQuestionWrap>
               <NumberTitle>
-                <span>2</span>
-                /3
+                <span>2</span>/3
               </NumberTitle>
               <ProvidedQuestionMainTitle>그 때 어떤 감정이 들었나요?</ProvidedQuestionMainTitle>
               <CommonTextArea value={secondContent} height="32.6rem" onChange={onChangeSecondContent} />
             </ProvidedQuestionWrap>
             <ProvidedQuestionWrap>
               <NumberTitle>
-                <span>3</span>
-                /3
+                <span>3</span>/3
               </NumberTitle>
               <ProvidedQuestionMainTitle>고생했어요! 스스로에게 한마디를 쓴다면?</ProvidedQuestionMainTitle>
               <CommonTextArea value={thirdContent} height="32.6rem" onChange={onChangeThirdContent} />

--- a/pages/posts/[postId]/edit.tsx
+++ b/pages/posts/[postId]/edit.tsx
@@ -75,7 +75,10 @@ const PostDetail = () => {
   const { data: folder, refetch: fetchFolderByPostId } = useFolderByPostIdQuery(postId);
   const { mutate: createFolder } = useCreateFolderMutation();
   const { mutate: updatePost } = useUpdatePostMutation();
-  const { confirmSystemDialog, cancelSystemDialog, removeRouteChangeEvent } = useSystemDialog(toggleDialog);
+  const { confirmSystemDialog, cancelSystemDialog, removeRouteChangeEvent } = useSystemDialog(() => {
+    toggleDialog();
+    setDialogType('cancel');
+  });
 
   const onCreateFolder = useCallback(() => {
     createFolder(folderName, {
@@ -84,8 +87,9 @@ const PostDetail = () => {
   }, [createFolder, folderName, toggleDialog]);
 
   const categoryOptions = categories ? Object.values(categories).flat() : [];
-
-  const selectedFolderName = folderListData?.folders.find(({ folderId }) => folderId === selectedState.folderId)?.folderName;
+  const selectedFolderName = folderListData?.folders.find(
+    ({ folderId }) => folderId === selectedState.folderId,
+  )?.folderName;
 
   const handleEdit = () => {
     const updatedForm = {
@@ -111,7 +115,7 @@ const PostDetail = () => {
     if (!router.isReady) return;
 
     if (selectedState.secondCategory === 'DONTKNOW') {
-      !isVisibleSheet && showCategoryBottomSheet();
+      !isVisibleSheet && showBottomSheetByType('category');
     }
 
     fetchPostById();
@@ -157,8 +161,8 @@ const PostDetail = () => {
     </>
   );
 
-  const showCategoryBottomSheet = () => {
-    setBottomSheetType('category');
+  const showBottomSheetByType = (type: string) => {
+    setBottomSheetType(type);
     toggleSheet();
   };
 
@@ -236,7 +240,7 @@ const PostDetail = () => {
             title="기록 이후 감정"
             selectedValue={selectedState.secondCategory}
             options={categoryOptions}
-            onClick={showCategoryBottomSheet}
+            onClick={() => showBottomSheetByType('category')}
           />
         </SelectContainer>
         {hasMultipleContent ? (

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -173,13 +173,15 @@ const PostListPage = () => {
   return (
     <>
       <CommonAppBar>
-        <CommonAppBar.Left>
-          <CommonIconButton iconName="left" alt="이전" onClick={() => router.back()} />
-          <HeaderTitle>{folderName || '모든 기록'}</HeaderTitle>
-        </CommonAppBar.Left>
+        {!isEditing && (
+          <CommonAppBar.Left>
+            <CommonIconButton iconName="left" alt="이전" onClick={() => router.back()} />
+            <HeaderTitle>{folderName || '모든 기록'}</HeaderTitle>
+          </CommonAppBar.Left>
+        )}
         <CommonAppBar.Right>
           {isEditing ? (
-            <TextButton onClick={handleSubmit}>완료</TextButton>
+            <CommonIconButton iconName="close" onClick={() => setIsEditing(false)} />
           ) : (
             <CommonIconButton iconName="more" alt="더보기" onClick={() => toggleSheet()} />
           )}


### PR DESCRIPTION
## Description

Fixes (issue QA 이슈)

## Changes

- 모든기록 background color 변경하였습니다.
- 모르겠어요 FAB 버튼 box-shadow 를 추가하였습니다.
- 리스트 페이지 편집 시, AppBar 에 닫기 버튼만 노출될 수 있게 변경하였습니다.
- 수정 페이지에서 뒤로가기 시, toggleDialog 함수 실행 및 dialogType 도 변경하였습니다.

**모든기록, 미분류 폴더 사이즈 동일하게 변경**
<img width="455" alt="스크린샷 2022-06-14 오후 11 26 42" src="https://user-images.githubusercontent.com/29244798/173605137-2c558a52-69b9-4c94-b946-1311356251fb.png">

**모르겠어요 버튼 box-shadow 추가**
<img width="459" alt="스크린샷 2022-06-14 오후 11 24 06" src="https://user-images.githubusercontent.com/29244798/173605149-3dc80c8d-4d3a-49bf-9b15-22c537903cba.png">

