### PR TITLE
리스트 페이지 QA 이슈 해결

### DIFF
--- a/components/Home/CollectedFolder/CollectedFolder.tsx
+++ b/components/Home/CollectedFolder/CollectedFolder.tsx
@@ -1,5 +1,5 @@
 import { MAX_THUMBNAIL_SIZE } from '@/shared/constants/home';
-import React, { HtmlHTMLAttributes } from 'react';
+import React, { HtmlHTMLAttributes, MouseEvent } from 'react';
 import {
   CollectedFolderContainer,
   Caption,
@@ -11,14 +11,25 @@ import {
 
 export interface CollectedFolderProps extends HtmlHTMLAttributes<HTMLDivElement> {
   count: number;
+  isEditMode: boolean;
   items: string[];
+  onClick: () => void;
 }
 
-const CollectedFolder = ({ count, items, ...rest }: CollectedFolderProps): React.ReactElement => {
+const CollectedFolder = ({ count, isEditMode, items, onClick }: CollectedFolderProps): React.ReactElement => {
   const invalidThumbnails = Array(MAX_THUMBNAIL_SIZE - items.length).fill('');
 
+  const handleClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (isEditMode) {
+      e.stopPropagation();
+      return;
+    }
+
+    onClick();
+  };
+
   return (
-    <CollectedFolderContainer {...rest}>
+    <CollectedFolderContainer onClick={handleClick}>
       <BoxContainer>
         {items.map((item, index) => (
           <FolderImage key={index} thumbnail={item} />

--- a/components/Home/Folder/Folder.tsx
+++ b/components/Home/Folder/Folder.tsx
@@ -1,6 +1,7 @@
 import React, { MouseEvent } from 'react';
 import Image from 'next/image';
 import { commaNumber } from '@/shared/utils/formatter';
+import { Folder } from '@/shared/type/folder';
 import {
   FolderContainer,
   FolderName,
@@ -14,10 +15,7 @@ import TrashIcon from 'public/svgs/trash.svg';
 import EditFolderIcon from 'public/svgs/editfolder.svg';
 
 export interface FolderProps {
-  folderId: number;
-  folderName: string;
-  count: number;
-  coverImage: string;
+  folder: Folder;
   isEditMode?: boolean;
   supportsEmptyImg?: boolean;
   onClick: (id: number) => void;
@@ -26,16 +24,15 @@ export interface FolderProps {
 }
 
 const Folder = ({
-  folderId,
-  count,
-  folderName,
-  coverImage,
+  folder,
   isEditMode = false,
   supportsEmptyImg = false,
   onClick,
   onEdit,
   onDelete,
 }: FolderProps): React.ReactElement => {
+  const { folderId, folderName, postCount, coverImg, default: isDefaultFolder } = folder;
+
   const handleDelete = (e: MouseEvent<HTMLSpanElement>) => {
     if (!onDelete) return;
     e.stopPropagation();
@@ -81,14 +78,14 @@ const Folder = ({
 
   return (
     <FolderContainer>
-      <BoxContainer onClick={handleClick} backgroundImage={!supportsEmptyImg || count !== 0 ? coverImage : ''}>
-        {isEditMode && renderDeleteButton()}
+      <BoxContainer onClick={handleClick} backgroundImage={!supportsEmptyImg || postCount !== 0 ? coverImg : ''}>
+        {!isDefaultFolder && isEditMode && renderDeleteButton()}
       </BoxContainer>
       <CaptionContainer>
-        {isEditMode && renderEditButton()}
+        {!isDefaultFolder && isEditMode && renderEditButton()}
         <div>
           <FolderName>{folderName}</FolderName>
-          <FolderCount>{commaNumber(count)}</FolderCount>
+          <FolderCount>{commaNumber(postCount)}</FolderCount>
         </div>
       </CaptionContainer>
     </FolderContainer>

--- a/components/Home/Folder/Folder.tsx
+++ b/components/Home/Folder/Folder.tsx
@@ -1,7 +1,6 @@
 import React, { MouseEvent } from 'react';
 import Image from 'next/image';
 import { commaNumber } from '@/shared/utils/formatter';
-import { Folder } from '@/shared/type/folder';
 import {
   FolderContainer,
   FolderName,
@@ -15,7 +14,11 @@ import TrashIcon from 'public/svgs/trash.svg';
 import EditFolderIcon from 'public/svgs/editfolder.svg';
 
 export interface FolderProps {
-  folder: Folder;
+  folderId: number;
+  folderName: string;
+  count: number;
+  coverImage: string;
+  isDefaultFolder?: boolean;
   isEditMode?: boolean;
   supportsEmptyImg?: boolean;
   onClick: (id: number) => void;
@@ -24,15 +27,17 @@ export interface FolderProps {
 }
 
 const Folder = ({
-  folder,
+  folderId,
+  count,
+  folderName,
+  coverImage,
+  isDefaultFolder = false,
   isEditMode = false,
   supportsEmptyImg = false,
   onClick,
   onEdit,
   onDelete,
 }: FolderProps): React.ReactElement => {
-  const { folderId, folderName, postCount, coverImg, default: isDefaultFolder } = folder;
-
   const handleDelete = (e: MouseEvent<HTMLSpanElement>) => {
     if (!onDelete) return;
     e.stopPropagation();
@@ -78,14 +83,14 @@ const Folder = ({
 
   return (
     <FolderContainer>
-      <BoxContainer onClick={handleClick} backgroundImage={!supportsEmptyImg || postCount !== 0 ? coverImg : ''}>
-        {!isDefaultFolder && isEditMode && renderDeleteButton()}
+      <BoxContainer onClick={handleClick} backgroundImage={!supportsEmptyImg || count !== 0 ? coverImage : ''}>
+        {isEditMode && !isDefaultFolder && renderDeleteButton()}
       </BoxContainer>
       <CaptionContainer>
-        {!isDefaultFolder && isEditMode && renderEditButton()}
+        {isEditMode && !isDefaultFolder && renderEditButton()}
         <div>
           <FolderName>{folderName}</FolderName>
-          <FolderCount>{commaNumber(postCount)}</FolderCount>
+          <FolderCount>{commaNumber(count)}</FolderCount>
         </div>
       </CaptionContainer>
     </FolderContainer>

--- a/components/Home/FolderList/FolderList.tsx
+++ b/components/Home/FolderList/FolderList.tsx
@@ -46,8 +46,12 @@ const FolderList = ({
         <HomeFolder
           supportsEmptyImg={supportsCollectedFolder}
           key={folder.folderId}
-          folder={folder}
+          folderId={folder.folderId}
+          folderName={folder.folderName}
+          count={folder.postCount}
+          coverImage={folder.coverImg}
           isEditMode={isEditMode}
+          isDefaultFolder={folder.default}
           onClick={onClick}
           onEdit={onEdit}
           onDelete={onDelete}

--- a/components/Home/FolderList/FolderList.tsx
+++ b/components/Home/FolderList/FolderList.tsx
@@ -35,17 +35,19 @@ const FolderList = ({
   return (
     <>
       {supportsCollectedFolder && (
-        <HomeCollectedFolder count={totalCount} items={thumbnailList || []} onClick={goToPosts} />
+        <HomeCollectedFolder
+          count={totalCount}
+          items={thumbnailList || []}
+          isEditMode={isEditMode}
+          onClick={goToPosts}
+        />
       )}
       {folderList.map((folder) => (
         <HomeFolder
           supportsEmptyImg={supportsCollectedFolder}
           key={folder.folderId}
-          folderId={folder.folderId}
-          folderName={folder.folderName}
-          count={folder.postCount}
-          coverImage={folder.coverImg}
-          isEditMode={isEditMode && !folder.default}
+          folder={folder}
+          isEditMode={isEditMode}
           onClick={onClick}
           onEdit={onEdit}
           onDelete={onDelete}

--- a/components/Post/PostItem/PostItem.tsx
+++ b/components/Post/PostItem/PostItem.tsx
@@ -147,6 +147,7 @@ const Dimmed = styled.div<Pick<PostItemProps, 'checked'>>`
   left: 0;
   width: 100%;
   height: 100%;
+  border-radius: 1.4rem;
 
   ${(props) =>
     props.checked &&

--- a/components/Post/PostList/PostList.style.ts
+++ b/components/Post/PostList/PostList.style.ts
@@ -1,0 +1,35 @@
+import theme from '@/styles/theme';
+import styled from 'styled-components';
+
+export const HeaderTitle = styled.h2`
+  margin-left: -0.2rem;
+  ${theme.fonts.h4};
+  color: ${theme.colors.white};
+`;
+
+export const BottomController = styled.div`
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  max-width: 48rem;
+  height: 9rem;
+  margin-left: -1.8rem;
+  display: flex;
+  justify-content: space-between;
+  background-color: ${theme.colors.black};
+  z-index: 1;
+`;
+
+export const BottomButton = styled.button<{ disabled: boolean }>`
+  ${theme.fonts.h6};
+  padding: 1.8rem 2rem;
+  color: ${theme.colors.white};
+
+  &:disabled {
+    color: ${theme.colors.gray3};
+  }
+`;
+
+export const LoadingContainer = styled.div`
+  margin: 2rem auto;
+`;

--- a/pages/posts/[postId].tsx
+++ b/pages/posts/[postId].tsx
@@ -121,7 +121,7 @@ const PostDetail = () => {
           <QuestionContainer>
             <ProvidedQuestionWrap>
               <MultipleLineText>
-                {me?.nickname}님에게 <br /> 어떤 일이 있었나요?
+                {post.my ? me?.nickname : '유저'}님에게 <br /> 어떤 일이 있었나요?
               </MultipleLineText>
               <CommonTextArea value={contents[0]} height="32.6rem" disabled />
             </ProvidedQuestionWrap>

--- a/pages/posts/[postId].tsx
+++ b/pages/posts/[postId].tsx
@@ -13,7 +13,7 @@ import { NumberTitle, ProvidedQuestionMainTitle, ProvidedQuestionWrap } from '@/
 import useBottomSheet from '@/hooks/useBottomSheet';
 import useDialog from '@/hooks/useDialog';
 import useToast from '@/hooks/useToast';
-import { useDeletePostMutation, usePostByIdQuery } from '@/hooks/apis';
+import { useDeletePostMutation, useMemberQuery, usePostByIdQuery } from '@/hooks/apis';
 import { useCategoryListQuery } from '@/hooks/apis/post/useCategoryListQuery';
 import { ToastType } from '@/shared/type/common';
 import { getPrevPath } from '@/shared/utils/storePathValues';
@@ -41,6 +41,7 @@ const PostDetail = () => {
 
   const { data: post } = usePostByIdQuery(postId);
   const { data: categories } = useCategoryListQuery();
+  const { data: me } = useMemberQuery();
 
   const folderId = router.query.folderId ? Number(router.query.folderId) : 0;
 
@@ -124,7 +125,7 @@ const PostDetail = () => {
                 /3
               </NumberTitle>
               <MultipleLineText>
-                카톡이름님에게 <br /> 어떤 일이 있었나요?
+                {me?.nickname}님에게 <br /> 어떤 일이 있었나요?
               </MultipleLineText>
               <CommonTextArea value={contents[0]} height="32.6rem" disabled />
             </ProvidedQuestionWrap>

--- a/pages/posts/[postId].tsx
+++ b/pages/posts/[postId].tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/Common';
 import Card from '@/components/Card/Card';
 import { CONTENT_SEPARATOR } from '@/shared/constants/question';
-import { NumberTitle, ProvidedQuestionMainTitle, ProvidedQuestionWrap } from '@/components/Question/Question.styles';
+import { ProvidedQuestionMainTitle, ProvidedQuestionWrap } from '@/components/Question/Question.styles';
 import useBottomSheet from '@/hooks/useBottomSheet';
 import useDialog from '@/hooks/useDialog';
 import useToast from '@/hooks/useToast';
@@ -120,28 +120,16 @@ const PostDetail = () => {
         {hasMultipleContent ? (
           <QuestionContainer>
             <ProvidedQuestionWrap>
-              <NumberTitle>
-                <span>1</span>
-                /3
-              </NumberTitle>
               <MultipleLineText>
                 {me?.nickname}님에게 <br /> 어떤 일이 있었나요?
               </MultipleLineText>
               <CommonTextArea value={contents[0]} height="32.6rem" disabled />
             </ProvidedQuestionWrap>
             <ProvidedQuestionWrap>
-              <NumberTitle>
-                <span>2</span>
-                /3
-              </NumberTitle>
               <ProvidedQuestionMainTitle>그 때 어떤 감정이 들었나요?</ProvidedQuestionMainTitle>
               <CommonTextArea value={contents[1]} height="32.6rem" disabled />
             </ProvidedQuestionWrap>
             <ProvidedQuestionWrap>
-              <NumberTitle>
-                <span>3</span>
-                /3
-              </NumberTitle>
               <ProvidedQuestionMainTitle>고생했어요! 스스로에게 한마디를 쓴다면?</ProvidedQuestionMainTitle>
               <CommonTextArea value={contents[2]} height="32.6rem" disabled />
             </ProvidedQuestionWrap>

--- a/pages/posts/[postId]/edit.tsx
+++ b/pages/posts/[postId]/edit.tsx
@@ -9,6 +9,7 @@ import {
   useCreateFolderMutation,
   useFolderByPostIdQuery,
   useFoldersQuery,
+  useMemberQuery,
   usePostByIdQuery,
   useUpdatePostMutation,
 } from '@/hooks/apis';
@@ -24,7 +25,7 @@ import {
   CommonFolderButton,
   CommonBottomSheetContainer,
 } from '@/components/Common';
-import { NumberTitle, ProvidedQuestionMainTitle, ProvidedQuestionWrap } from '@/components/Question/Question.styles';
+import { ProvidedQuestionMainTitle, ProvidedQuestionWrap } from '@/components/Question/Question.styles';
 import CategorySelector from '@/components/CategorySelector/CategorySelector';
 import BottomSheetFolderList from '@/components/BottomSheetFolderList/BottomSheetFolderList';
 import BottomSheetCategoryList from '@/components/BottomSheetCategoryList/BottomSheetCategoryList';
@@ -73,6 +74,7 @@ const PostDetail = () => {
   const { data: post, refetch: fetchPostById } = usePostByIdQuery(postId);
   const { data: categories } = useCategoryListQuery();
   const { data: folder, refetch: fetchFolderByPostId } = useFolderByPostIdQuery(postId);
+  const { data: me } = useMemberQuery();
   const { mutate: createFolder } = useCreateFolderMutation();
   const { mutate: updatePost } = useUpdatePostMutation();
   const { confirmSystemDialog, cancelSystemDialog, removeRouteChangeEvent } = useSystemDialog(() => {
@@ -246,25 +248,16 @@ const PostDetail = () => {
         {hasMultipleContent ? (
           <QuestionContainer>
             <ProvidedQuestionWrap>
-              <NumberTitle>
-                <span>1</span>/3
-              </NumberTitle>
               <MultipleLineText>
-                카톡이름님에게 <br /> 어떤 일이 있었나요?
+                {me?.nickname}님에게 <br /> 어떤 일이 있었나요?
               </MultipleLineText>
               <CommonTextArea value={firstContent} height="32.6rem" onChange={onChangeFirstContent} />
             </ProvidedQuestionWrap>
             <ProvidedQuestionWrap>
-              <NumberTitle>
-                <span>2</span>/3
-              </NumberTitle>
               <ProvidedQuestionMainTitle>그 때 어떤 감정이 들었나요?</ProvidedQuestionMainTitle>
               <CommonTextArea value={secondContent} height="32.6rem" onChange={onChangeSecondContent} />
             </ProvidedQuestionWrap>
             <ProvidedQuestionWrap>
-              <NumberTitle>
-                <span>3</span>/3
-              </NumberTitle>
               <ProvidedQuestionMainTitle>고생했어요! 스스로에게 한마디를 쓴다면?</ProvidedQuestionMainTitle>
               <CommonTextArea value={thirdContent} height="32.6rem" onChange={onChangeThirdContent} />
             </ProvidedQuestionWrap>
@@ -284,7 +277,9 @@ const PostDetail = () => {
         <SpaceBetweenContainer>
           <OptionTitle>폴더</OptionTitle>
           <FolderWrap>
-            <CommonFolderButton onClick={toggleSheet}>{selectedFolderName}</CommonFolderButton>
+            <CommonFolderButton onClick={() => showBottomSheetByType('folder')}>
+              {selectedFolderName}
+            </CommonFolderButton>
             <CustomImage src={FolderPlus} alt="추가" onClick={toggleCreateDialog} />
           </FolderWrap>
         </SpaceBetweenContainer>


### PR DESCRIPTION
## Description

Fixes (issue 리스트 페이지 QA)

## Changes

- 수정페이지, 상세페이지에서 Nickname 노출되게끔 수정하였습니다.
  - 내 글일 때는 nickname 노출하고 아닐 때는 **유저** 라고 해두었습니다. 해당 부분은 기획 확인해서 다시 수정 예정입니다.
- 수정, 상세페이지에서 질문 번호를 제거하였습니다.
- Folder 컴포넌트 미분류, 모든폴더 상관없이 편집 모드일 때는 클릭되지 않게 수정하였습니다.
