### PR TITLE
date format 함수 Safari 버그 수정

### DIFF
--- a/shared/utils/date.ts
+++ b/shared/utils/date.ts
@@ -1,4 +1,10 @@
-export const formatDatetime = (date: string) => {
+export const formatDatetime = (inputDate: string) => {
+  const [date, time] = inputDate.split(' ');
+  const [year, month, day] = date.split('-');
+  const [hour, min] = time.split(':');
+
+  const dateUTC = Date.UTC(Number(year), Number(month) - 1, Number(day), Number(hour), Number(min));
+
   const formatter = new Intl.DateTimeFormat('ko-KR', {
     year: 'numeric',
     month: 'long',
@@ -6,7 +12,7 @@ export const formatDatetime = (date: string) => {
     hour: '2-digit',
     minute: '2-digit',
     hourCycle: 'h24',
-  }).formatToParts(new Date(`${date}Z`));
+  }).formatToParts(new Date(dateUTC));
 
   const formattedDate = formatter.map(({ type, value }) => (type === 'dayPeriod' ? '' : value)).join('');
   return formattedDate.replace('  ', ' ');


### PR DESCRIPTION
## Description

Safari 에서 2022-01-01 13:00:00Z 에 대한 string 을 date 로 생성할 때, Invalid Date 로 처리되어
에러가 발생하고 있습니다. (사실 이 부분에서 제가 좀 더 확실한 방법으로 했어야 했는데, 단순히 Z 를 붙여서 작업하는 방식으로 해서 그런 것 같습니다ㅠㅠ)

## Changes

1. 2022-01-01 13:00:00 부분을 year, month, date, hour, min 으로 split 을 하고
2. Date.UTC(year, month, date, hour, min) 으로 UTC 밀리초로 변환
3. new Date() 생성자로 호출하여 로컬 타임존에 맞춰 date 객체를 반환하여
4. Intl.DateTimeFormat 을 이용하여 yyyy년 mm월 dd일 hh:mm 로 노출될 수 있게 작업하였습니다.
