### PR TITLE
Fix: Textfield, 수정 페이지 QA 이슈 수정

### DIFF
--- a/components/Common/TextField/TextField.stories.tsx
+++ b/components/Common/TextField/TextField.stories.tsx
@@ -21,5 +21,4 @@ export const NoBorder = Template.bind({});
 NoBorder.args = {
   placeholder: '태그를 추가해주세요.',
   rightSideIcon: WhiteAdd,
-  hasBorder: false,
 };

--- a/components/Common/TextField/TextField.styles.ts
+++ b/components/Common/TextField/TextField.styles.ts
@@ -32,7 +32,7 @@ export const Container = styled.div<Pick<TextFieldProps, 'supportsMaxLength' | '
   flex: 0 1 auto;
 `;
 
-export const Input = styled.input<Pick<TextFieldProps, 'borderRadius' | 'hasBorder' | 'height'>>`
+export const Input = styled.input<Pick<TextFieldProps, 'borderRadius' | 'height'>>`
   text-align: start;
   cursor: text;
   width: 100%;
@@ -46,14 +46,11 @@ export const Input = styled.input<Pick<TextFieldProps, 'borderRadius' | 'hasBord
   height: ${({ height }) => height || '4rem'};
 
   ${theme.fonts.body};
-  ${({ hasBorder }) =>
-    hasBorder
-      ? css`
-          border: 0.1rem solid ${theme.colors.gray4};
-        `
-      : css`
-          border: none;
-        `};
+  border: none;
+
+  :focus {
+    border: 0.1rem solid ${theme.colors.gray4};
+  }
 `;
 
 export const RightSideIcon = styled.img<{ isFocused: boolean }>`

--- a/components/Common/TextField/TextField.tsx
+++ b/components/Common/TextField/TextField.tsx
@@ -6,7 +6,6 @@ export interface TextFieldProps extends React.InputHTMLAttributes<HTMLInputEleme
   rightSideIcon?: string;
   height?: string;
   borderRadius?: '1rem' | '0.4rem';
-  hasBorder?: boolean;
   supportsMaxLength?: boolean;
   onClickRightSideIcon?: () => void;
   hasRightSideIcon?: boolean;
@@ -19,7 +18,6 @@ const TextField = ({
   rightSideIcon,
   height,
   borderRadius,
-  hasBorder,
   maxLength,
   supportsMaxLength = false,
   onClickRightSideIcon,
@@ -42,7 +40,6 @@ const TextField = ({
             setIsFocused(false);
             onBlur?.(event);
           }}
-          hasBorder={hasBorder}
           maxLength={maxLength}
           {...restTextFieldProps}
         />

--- a/components/Common/Toggle/Toggle.styles.ts
+++ b/components/Common/Toggle/Toggle.styles.ts
@@ -18,7 +18,7 @@ export const Trigger = styled.input`
 
 export const ToggleText = styled.span<{ checked: boolean }>`
   position: absolute;
-  top: 0.8rem;
+  top: 0.7rem;
   right: 1.2rem;
   ${theme.fonts.caption2};
   color: ${theme.colors.black};

--- a/components/Common/index.tsx
+++ b/components/Common/index.tsx
@@ -17,3 +17,4 @@ export { default as CommonIconButton } from './IconButton/IconButton';
 export { default as CommonCheckbox } from './Checkbox/Checkbox';
 export { default as CommonFolderButton } from './Tag/FolderButton';
 export { default as CommonLoading } from './Loading/Loading';
+export { default as CommonSelectButton } from './SelectButton/SecondCategorySelect';

--- a/components/CurrentEmotion/CurrentEmotion.tsx
+++ b/components/CurrentEmotion/CurrentEmotion.tsx
@@ -20,17 +20,19 @@ import { PostRequestType, PostResponseType } from '@/shared/type/post';
 import postService from '@/service/apis/postService';
 
 import { ButtonWrapper } from '@/pages/write';
-import Button from '../Common/Button/Button';
-import SelectButton from '../Common/SelectButton/SecondCategorySelect';
-import Toggle from '../Common/Toggle/Toggle';
-import FolderButton from '../Common/Tag/FolderButton';
-import TextField from '../Common/TextField/TextField';
-import TagButton from '../Common/TagButton/TagButton';
+import {
+  CommonDialog,
+  CommonSelectButton,
+  CommonBottomSheetContainer,
+  CommonButton,
+  CommonToggle,
+  CommonFolderButton,
+  CommonTextField,
+  CommonTagButton,
+} from '@/components/Common';
 import { MainTitle } from '@/components/PreEmotion/PreEmotion';
-import { CommonBottomSheetContainer } from '@/components/Common';
 import BottomSheetFolderList from '@/components/BottomSheetFolderList/BottomSheetFolderList';
 import FolderPlus from 'public/svgs/folderplus.svg';
-import { CommonDialog } from '@/components/Common';
 import DialogFolderForm from '@/components/Dialog/DialogFolderForm';
 import Whiteadd from 'public/svgs/whiteadd.svg';
 import FolderIcon from 'public/svgs/folder.svg';
@@ -54,7 +56,6 @@ interface CurrentEmotionProps {
 const CurrentEmotion = ({ removeRouteChangeEvent }: CurrentEmotionProps) => {
   const notify = useToast();
   const nextProgressStep = useNextProgressStep();
-  const [isTypingMode, setTypingMode] = useState(false);
   const [isDisclose, setDisclose] = useState(false);
   const [tagList, setTagList] = useState<string[]>([]);
   const [selectedFolderName, setSelectFolderName] = useState('폴더선택');
@@ -99,13 +100,6 @@ const CurrentEmotion = ({ removeRouteChangeEvent }: CurrentEmotionProps) => {
       });
     },
   });
-
-  const onTextFieldBlur = () => {
-    setTypingMode(false);
-  };
-  const onTextFieldFocus = () => {
-    setTypingMode(true);
-  };
 
   const onChangeDisclose = () => {
     setSelectState((prev) => ({ ...prev, disclosure: !isDisclose }));
@@ -192,21 +186,19 @@ const CurrentEmotion = ({ removeRouteChangeEvent }: CurrentEmotionProps) => {
         {me?.nickname ?? DEFAULT_NICKNAME}님의 <br />
         지금 감정은 어떠세요?
       </MainTitle>
-      <SelectButton title="☺️ &nbsp; 한결 나아졌어요" secondaryCategorytype="positive" />
-      <SelectButton title="😞 &nbsp; 여전히" secondaryCategorytype="negative" />
-      <SelectButton title="🤔 &nbsp; 변화가 없었어요" secondaryCategorytype="natural" />
+      <CommonSelectButton title="☺️ &nbsp; 한결 나아졌어요" secondaryCategorytype="positive" />
+      <CommonSelectButton title="😞 &nbsp; 여전히" secondaryCategorytype="negative" />
+      <CommonSelectButton title="🤔 &nbsp; 변화가 없었어요" secondaryCategorytype="natural" />
       <Divider />
       <OptionWrapper>
         <OptionTitle>태그</OptionTitle>
         <TextFieldWrap>
-          <TextField
+          <CommonTextField
             value={tagValue}
             rightSideIcon={Whiteadd.src}
-            hasBorder={isTypingMode}
-            onFocus={onTextFieldFocus}
-            onBlur={onTextFieldBlur}
             onChange={onChangeValue}
             onKeyPress={onKeyPressEnter}
+            hasRightSideIcon={true}
             onClickRightSideIcon={onClickRightSideIcon}
             placeholder="태그를 추가해주세요."
           />
@@ -214,35 +206,35 @@ const CurrentEmotion = ({ removeRouteChangeEvent }: CurrentEmotionProps) => {
         <TagButtonWrap>
           {tagList.length > 0 ? (
             tagList.map((content, index) => (
-              <TagButton canDelete onClick={onDeleteTag(index)} key={content}>
+              <CommonTagButton canDelete onClick={onDeleteTag(index)} key={content}>
                 #{content}
-              </TagButton>
+              </CommonTagButton>
             ))
           ) : (
-            <TagButton exampleTagMode>#태그는 5개까지 입력 가능해요.</TagButton>
+            <CommonTagButton exampleTagMode>#태그는 5개까지 입력 가능해요.</CommonTagButton>
           )}
         </TagButtonWrap>
         <div className="space-between">
           <OptionTitle>공개</OptionTitle>
-          <Toggle checked={isDisclose} onChange={onChangeDisclose} />
+          <CommonToggle checked={isDisclose} onChange={onChangeDisclose} />
         </div>
         <div className="space-between">
           <OptionTitle>폴더</OptionTitle>
           <FolderWrap>
-            <FolderButton onClick={toggleSheet}>{selectedFolderName}</FolderButton>
+            <CommonFolderButton onClick={toggleSheet}>{selectedFolderName}</CommonFolderButton>
             <CustomImage src={FolderPlus} alt="FolderPlus" onClick={toggleDialog} />
           </FolderWrap>
         </div>
       </OptionWrapper>
       <ButtonWrapper>
-        <Button
+        <CommonButton
           color="primary"
           onClick={onSubmit}
           size="large"
           disabled={selectedState.secondCategory === '' || !selectedState.folderId}
         >
           감정기록 완료
-        </Button>
+        </CommonButton>
       </ButtonWrapper>
       {dialogVisible && (
         <CommonDialog

--- a/components/Dialog/DialogDelete.tsx
+++ b/components/Dialog/DialogDelete.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import DialogWarning from './DialogWarning';
+
+const DialogDelete = () => {
+  return <DialogWarning>기록을 삭제하시겠어요?</DialogWarning>;
+};
+
+export default DialogDelete;

--- a/components/Dialog/DialogFolderForm.tsx
+++ b/components/Dialog/DialogFolderForm.tsx
@@ -21,7 +21,6 @@ const DialogFolderForm = ({ isEditMode = false, value, onChange }: DialogFolderF
         supportsMaxLength
         maxLength={10}
         value={value}
-        hasBorder={true}
         onChange={onChange}
         autoFocus
       />

--- a/components/Post/PostDetail.style.ts
+++ b/components/Post/PostDetail.style.ts
@@ -6,13 +6,14 @@ export const PostDetailContainer = styled.section`
   display: flex;
   flex-direction: column;
   padding-bottom: 8rem;
+  margin-top: 2rem;
 `;
 
 export const TagContainer = styled.div`
   display: flex;
   overflow-x: auto;
   padding: 0 1.8rem;
-  margin: 2rem -1.8rem 2.4rem;
+  margin: 0 -1.8rem 2.4rem;
 
   div {
     flex: 0 0 auto;

--- a/components/Post/PostEdit/Question.tsx
+++ b/components/Post/PostEdit/Question.tsx
@@ -32,10 +32,12 @@ const Question = ({
       {hasMultipleContent ? (
         <QuestionContainer>
           <QuestionWrap>
-            <NumberTitle>
-              <span>1</span>
-              /3
-            </NumberTitle>
+            {!disabled && (
+              <NumberTitle>
+                <span>1</span>
+                /3
+              </NumberTitle>
+            )}
             <MultipleLineText>
               {nickname || DEFAULT_NICKNAME}님, <br />
               어떤 일이 있었나요?
@@ -49,10 +51,12 @@ const Question = ({
             />
           </QuestionWrap>
           <QuestionWrap>
-            <NumberTitle>
-              <span>2</span>
-              /3
-            </NumberTitle>
+            {!disabled && (
+              <NumberTitle>
+                <span>2</span>
+                /3
+              </NumberTitle>
+            )}
             <ProvidedQuestionMainTitle>그 때 어떤 감정이 들었나요?</ProvidedQuestionMainTitle>
             <CommonTextArea
               value={secondContent}
@@ -63,10 +67,12 @@ const Question = ({
             />
           </QuestionWrap>
           <QuestionWrap>
-            <NumberTitle>
-              <span>3</span>
-              /3
-            </NumberTitle>
+            {!disabled && (
+              <NumberTitle>
+                <span>3</span>
+                /3
+              </NumberTitle>
+            )}
             <ProvidedQuestionMainTitle>고생했어요! 스스로에게 한마디를 쓴다면?</ProvidedQuestionMainTitle>
             <CommonTextArea
               value={thirdContent}

--- a/hooks/apis/folder/useFolderMutation.ts
+++ b/hooks/apis/folder/useFolderMutation.ts
@@ -2,18 +2,23 @@ import { useMutation } from 'react-query';
 import folderService from '@/service/apis/folderService';
 import { QUERY_KEY } from '@/shared/constants/queryKey';
 import { queryClient } from '@/shared/utils/queryClient';
+import { FolderSuccessResponse } from '@/shared/type/folder';
+import { AxiosError } from 'axios';
 
 export const useCreateFolderMutation = () =>
-  useMutation((folderName: string) => folderService.createFolder(folderName), {
-    onSuccess: () => {
-      queryClient.invalidateQueries(QUERY_KEY.GET_FOLDERS);
+  useMutation<FolderSuccessResponse, AxiosError, string>(
+    (folderName: string) => folderService.createFolder(folderName),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(QUERY_KEY.GET_FOLDERS);
+      },
+      onError: (error) => {
+        // TODO: toast로 에러메시지 띄워주기, 문제 : 현재는 toast가 hook이라서 분기문 안에서 호출 불가, toast를 간소화 해야됨
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        console.log(({ error }.error as any).response.data.msg);
+      },
     },
-    onError: (error) => {
-      // TODO: toast로 에러메시지 띄워주기, 문제 : 현재는 toast가 hook이라서 분기문 안에서 호출 불가, toast를 간소화 해야됨
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      console.log(({ error }.error as any).response.data.msg);
-    },
-  });
+  );
 
 export const useUpdateFolderMutation = () =>
   useMutation(({ id, folderName }: { id: number; folderName: string }) => folderService.updateFolder(id, folderName), {

--- a/pages/posts/[postId].tsx
+++ b/pages/posts/[postId].tsx
@@ -102,11 +102,13 @@ const PostDetail = () => {
         )}
       </CommonAppBar>
       <PostDetailContainer>
-        <TagContainer>
-          {post.tags.map((tag: string, index: number) => (
-            <CommonTagButton key={index}>#{tag}</CommonTagButton>
-          ))}
-        </TagContainer>
+        {!!post.tags.length && (
+          <TagContainer>
+            {post.tags.map((tag: string, index: number) => (
+              <CommonTagButton key={index}>#{tag}</CommonTagButton>
+            ))}
+          </TagContainer>
+        )}
         <CardContainer>
           <Card firstEmotion={post.firstCategory} secondEmotion={post.secondCategory}>
             그땐 {getCategoryDescription(post.firstCategory)}, 지금은 {getCategoryDescription(post.secondCategory)}

--- a/service/apis/folderService.ts
+++ b/service/apis/folderService.ts
@@ -18,7 +18,7 @@ const folderService = {
 
     return data;
   },
-  createFolder: async (folderName: string): Promise<ServerResponse> => {
+  createFolder: async (folderName: string) => {
     const { data } = await fetcher('post', '/api/v1/folders', { folderName });
 
     return data;

--- a/shared/type/folder.ts
+++ b/shared/type/folder.ts
@@ -5,3 +5,8 @@ export interface Folder {
   postCount: number;
   default: boolean;
 }
+
+export interface FolderSuccessResponse {
+  folderId: number;
+  folderName: string;
+}


### PR DESCRIPTION
## Description

https://www.notion.so/depromeet/QA-27c48bd47fd94b6f94e17b464532caeb
QA 이슈 수정

## Changes
- TextField 컴포넌트에 있는 hasBorder 를 제거하고, focus style 로 변경하였습니다. 
  - focus 됐을 때 border 가 변경되어야 한다면 hasBorder 와 같은 props 없이 focus 스타일로만 할 수 있어서 수정했습니다.
- Toggle button style 수정하였습니다.
- 수정 페이지에서 createFolderMutation onSuccess 에서 추가된 folderId 를 할당하였습니다.
