### PR TITLE
style: PostItem 컴포넌트 스타일 수정 (#192)

### DIFF
--- a/components/Post/PostItem/PostItem.tsx
+++ b/components/Post/PostItem/PostItem.tsx
@@ -12,7 +12,7 @@ import { commaNumber } from '@/shared/utils/formatter';
 
 export interface PostItemProps {
   post: Post;
-  supportsTag?: boolean;
+  isSearchedByTag?: boolean;
   canEdit?: boolean;
   isMine?: boolean;
   isEditing?: boolean;
@@ -22,7 +22,7 @@ export interface PostItemProps {
 
 const PostItem = ({
   post: { id, tags, firstCategoryName, secondCategoryName, content, createdAt, views },
-  supportsTag = false,
+  isSearchedByTag = false,
   isMine = false,
   isEditing = false,
   checked = false,
@@ -40,26 +40,30 @@ const PostItem = ({
           <Dimmed checked={checked} />
         </>
       )}
-      {supportsTag && (
+      {isSearchedByTag && (
         <TagList>
           {tags.map((tag: string, index: number) => (
             <CommonTagButton key={index}>#{tag}</CommonTagButton>
           ))}
         </TagList>
       )}
-      <ChipContainer>
-        {isMine && <HighlightButton>MY</HighlightButton>}
-        <CommonChipButton>{firstCategoryName}</CommonChipButton>
-        <Arrow>
-          <Image src={ArrowRightIcon} alt="" width={16} height={16} />
-        </Arrow>
-        <CommonChipButton>{secondCategoryName}</CommonChipButton>
-      </ChipContainer>
+      {!isSearchedByTag && (
+        <ChipContainer>
+          <CommonChipButton>{firstCategoryName}</CommonChipButton>
+          <Arrow>
+            <Image src={ArrowRightIcon} alt="" width={16} height={16} />
+          </Arrow>
+          <CommonChipButton>{secondCategoryName}</CommonChipButton>
+        </ChipContainer>
+      )}
       <Content>{firstContent}</Content>
-      <CaptionContainer>
-        <Caption>{formatDate(createdAt)}</Caption>
-        {supportsTag && <Caption>조회수 {commaNumber(views)}</Caption>}
-      </CaptionContainer>
+      <BottomContainer>
+        {isMine && <HighlightButton>MY</HighlightButton>}
+        <CaptionContainer>
+          <Caption>{formatDate(createdAt)}</Caption>
+          {isSearchedByTag && <Caption>조회수 {commaNumber(views)}</Caption>}
+        </CaptionContainer>
+      </BottomContainer>
     </PostItemContainer>
   );
 };
@@ -91,7 +95,6 @@ const TagList = styled.div`
   flex-wrap: wrap;
   overflow-y: hidden;
   height: 3rem;
-  margin-bottom: 2.4rem;
 
   div ~ div {
     margin-left: 1.2rem;
@@ -109,10 +112,18 @@ const Content = styled.p`
 const ChipContainer = styled.div`
   display: flex;
   align-items: center;
+
+  ${TagList} ~ & {
+    margin-top: 2.4rem;
+  }
 `;
 
 const Arrow = styled.i`
   margin: 0 0.8rem;
+`;
+
+const BottomContainer = styled.div`
+  display: flex;
 `;
 
 const CaptionContainer = styled.div`
@@ -141,11 +152,7 @@ const Caption = styled.span`
 
 const HighlightButton = styled.button`
   ${theme.fonts.caption1};
-  margin-right: 1.2rem;
-  padding: 0.4rem 0.8rem;
-  border-radius: 1.1rem;
-  background-color: ${theme.colors.primary};
-  color: ${theme.colors.black};
+  color: ${theme.colors.primary};
 `;
 
 const CheckboxContainer = styled.div<Pick<PostItemProps, 'checked'>>`

--- a/pages/search/result/index.tsx
+++ b/pages/search/result/index.tsx
@@ -78,7 +78,7 @@ const SearchedResultByTag = () => {
           <PostItem
             key={searchedPost.id}
             post={searchedPost}
-            supportsTag={true}
+            isSearchedByTag={true}
             isMine={searchedPost.my}
             onClick={async () => {
               try {


### PR DESCRIPTION
## Description

Fixes (issue #192)

## Changes

- PostItem 컴포넌트 마크업 구조 수정하였습니다.
- supportsTag -> isSearchedByTag 로 props naming 수정하였습니다.
  - 검색 페이지에서 tag on/off 만 하고자 supportsTag 로 작성했었는데, 검색 페이지에서 분기처리가 많이 되어 isSearchedByTag 로 하였습니다.

## 스크린샷

**검색 페이지**
<img width="472" alt="스크린샷 2022-06-22 오후 10 48 15" src="https://user-images.githubusercontent.com/29244798/175045891-a44cc3d0-de81-4577-acb8-cdb96bcdaef1.png">

**검색 페이지 - 내 글**
<img width="478" alt="스크린샷 2022-06-22 오후 10 46 50" src="https://user-images.githubusercontent.com/29244798/175045911-a0e6d947-d8e0-471a-8464-8cdaed06291f.png">

**내 글 리스트**
<img width="475" alt="스크린샷 2022-06-22 오후 10 48 22" src="https://user-images.githubusercontent.com/29244798/175045897-82db4b13-c727-4337-ac3e-59d5467c7868.png">

