### PR TITLE
Fix: 모르겠어요 페이지에서 상세 페이지로 이동시 404 에러 

### DIFF
--- a/pages/posts/dontknow-feelings.tsx
+++ b/pages/posts/dontknow-feelings.tsx
@@ -25,7 +25,9 @@ const PostList = () => {
           지금은 어떤 감정이 드세요?
         </Title>
         {postList.length ? (
-          postList.map((post) => <PostItem key={post.id} post={post} onClick={() => router.push(`posts/${post.id}`)} />)
+          postList.map((post) => (
+            <PostItem key={post.id} post={post} onClick={() => router.push(`/posts/${post.id}`)} />
+          ))
         ) : (
           <ImageMessage src={ListEmpty} alt="기록이 없어요.">
             기록이 없어요.


### PR DESCRIPTION
## Description

https://www.moodpic.kr/posts/posts/4fbf8916-511d-4073-9e84-72c75617762a

위와 같이 /posts/posts/${postId} 로 이동되며 없는 페이지라서 404가 노출됩니다.

## Changes

/posts/dontknow-feelings 페이지에서 PostItem 클릭 시, router.push 함수를 실행할 때 상대경로로 잘못 작성하여
`/posts/posts/${postId}` 로 이동하면서 404 에러가 발생하였습니다.

router.push 할 때 `/posts/${post.id}` 로 이동할 수 있게 변경하였습니다.