### PR TITLE
Fix: auth token 만료되었을 때, 로그인으로 가지 않고 API 401 에러만 나는 이슈 수정 

### DIFF
--- a/shared/utils/fetcher.ts
+++ b/shared/utils/fetcher.ts
@@ -39,6 +39,7 @@ const onResponseError = (error: AxiosError) => {
 
   if (token && error.response?.status === 401) {
     removeCookies('authToken');
+    window.location.reload();
   }
 };
 

--- a/shared/utils/fetcher.ts
+++ b/shared/utils/fetcher.ts
@@ -1,6 +1,6 @@
-import axios from 'axios';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 import qs from 'qs';
-import { getCookie, setCookies } from '@/hooks/useCookie';
+import { getCookie, removeCookies, setCookies } from '@/hooks/useCookie';
 import { AUTH_TOKEN } from '@/shared/constants/auth';
 
 axios.defaults.paramsSerializer = (params: object) => {
@@ -29,6 +29,20 @@ axios.interceptors.request.use((config) => {
 
   return config;
 });
+
+const onResponse = (response: AxiosResponse): AxiosResponse => {
+  return response;
+};
+
+const onResponseError = (error: AxiosError) => {
+  const token = getCookie(AUTH_TOKEN);
+
+  if (token && error.response?.status === 401) {
+    removeCookies('authToken');
+  }
+};
+
+axios.interceptors.response.use(onResponse, onResponseError);
 
 const fetcher = async (method: 'get' | 'post' | 'patch' | 'delete', url: string, ...rest: object[]) => {
   try {


### PR DESCRIPTION
## Description

Fixes (issue #234)

authToken 은 있는데 해당 토큰이 만료되어 api 호출 시 401에러만 발생하고 로그인 페이지로 이동하지 않는 이슈

## Changes

authToken 이 없을 때는 middleware 에서 처리가 되지만, authToken 이 있으면 인증된 회원으로 간주하여 메인페이지 접근이 가능합니다.
-> axios response interceptor 에서 error.response.status 가 401 인 경우 token 을 제거하고, 새로고침을 하여 로그인으로 이동하게끔 하였습니다.

moodpic 에 오랜만에 들어가니 토큰이 만료되어 위와 같은 이슈를 맞이하여 수정해보았습니다.